### PR TITLE
build: Added snapshot deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,23 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: mvn -B install -DskipTests dependency:go-offline
+      # Build
+      - run: mvn -B -s .circleci/settings.xml install -DskipTests dependency:go-offline
 
+      # Save the dependency cache for future runs
       - save_cache:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}-{{ checksum "cache/pom.xml" }}-{{ checksum "server/pom.xml" }}
 
-      # run tests!
-      - run: mvn -B verify
+      # Test
+      - run: mvn -B -s .circleci/settings.xml verify
+
+      # Deploy
+      - deploy:
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              mvn -B -s .circleci/settings.xml deploy
+            fi
 
       - run: bash <(curl -s https://codecov.io/bash)

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -1,0 +1,33 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+    <servers>
+        <server>
+            <id>sonatype-nexus-snapshots</id>
+            <username>${env.SONATYPE_USER}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
+        </server>
+        <server>
+            <id>sonatype-nexus-staging</id>
+            <username>${env.SONATYPE_USER}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
+        </server>
+    </servers>
+    <profiles>
+        <profile>
+            <id>sonatype-staging</id>
+            <repositories>
+                <repository>
+                    <id>sonatype-staging</id>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>sonatype-staging</activeProfile>
+    </activeProfiles>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,48 @@
         <!-- Maven Plugin Versions -->
         <jacoco-maven-plugin.version>0.8.0</jacoco-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+        <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>
+
+    <name>java-control-plane</name>
+    <url>https://github.com/envoyproxy/java-control-plane</url>
+    <description>
+        The Envoy java-control-plane is a Java-based library for building
+        implementations of the data-plane-api.
+    </description>
+
+    <organization>
+        <name>The Envoy Project</name>
+        <url>http://envoyproxy.io/</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+    <inceptionYear>2018</inceptionYear>
+
+    <scm>
+        <url>https://github.com/envoyproxy/java-control-plane</url>
+        <connection>scm:git:git://github.com/envoyproxy/java-control-plane.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/envoyproxy/java-control-plane.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <developers>
+        <developer>
+            <id>envoyproxy.io</id>
+            <name>The Envoy Contributors</name>
+            <email>envoy-users@googlegroups.com</email>
+            <url>http://envoyproxy.io/</url>
+            <organization>The Envoy Project</organization>
+            <organizationUrl>http://envoyproxy.io/</organizationUrl>
+        </developer>
+    </developers>
 
     <dependencies>
         <!-- Test Dependencies -->
@@ -50,6 +91,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <build>
         <plugins>
@@ -84,6 +132,41 @@
             </plugin>
 
             <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
+                <configuration>
+                    <author>false</author>
+                    <breakiterator>true</breakiterator>
+                    <doclint>accessibility,html,reference,syntax</doclint>
+                    <keywords>true</keywords>
+                    <version>false</version>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources-no-fork</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco-maven-plugin.version}</version>
@@ -101,6 +184,18 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${nexus-staging-maven-plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Initial steps towards resolving #5. Maven Central access has been granted for the `io.envoyproxy` group and this PR adds automatic snapshot deployments for all merges to `master`.