### PR TITLE
build: Enable protoc plugin staleness check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           - v1-dependencies-
 
       # Build
-      - run: mvn -B -s .circleci/settings.xml install -DskipTests dependency:go-offline
+      - run: mvn -B -s .circleci/settings.xml install -DskipTests -Dmaven.javadoc.skip=true dependency:go-offline
 
       # Save the dependency cache for future runs
       - save_cache:
@@ -30,7 +30,7 @@ jobs:
           key: v1-dependencies-{{ checksum "pom.xml" }}-{{ checksum "cache/pom.xml" }}-{{ checksum "server/pom.xml" }}
 
       # Test
-      - run: mvn -B -s .circleci/settings.xml verify
+      - run: mvn -B -s .circleci/settings.xml -Dmaven.javadoc.skip=true verify
 
       # Deploy
       - deploy:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -41,6 +41,9 @@
                     <protocArtifact>com.google.protobuf:protoc:3.5.1-1:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.9.0:exe:${os.detected.classifier}</pluginArtifact>
+
+                    <checkStaleness>true</checkStaleness>
+                    <staleMillis>10000</staleMillis>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
The protoc plugin is currently configured to always regenerate proto sources, regardless of whether or not there are actual changes. This change configures the plugin to do a staleness check, which avoid regeneration/recompilation when no changes have been made.

The build has also been modified in order to skip javadoc processing during the initial build/test runs.

Signed-off-by: Joey Bratton <jbratton@salesforce.com>