### PR TITLE
cache: Make the SimpleCache group key generic

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/Cache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/Cache.java
@@ -6,14 +6,14 @@ import javax.annotation.concurrent.ThreadSafe;
  * {@code Cache} is a generic config cache with support for watchers.
  */
 @ThreadSafe
-public interface Cache extends ConfigWatcher {
+public interface Cache<T> extends ConfigWatcher {
 
   /**
    * Set the {@link Snapshot} for the given node group. Snapshots should have distinct versions and be internally
    * consistent (i.e. all referenced resources must be included in the snapshot).
    *
-   * @param group hash key for the node group
+   * @param group group identifier
    * @param snapshot a versioned collection of node config data
    */
-  void setSnapshot(String group, Snapshot snapshot);
+  void setSnapshot(T group, Snapshot snapshot);
 }

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/NodeGroup.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/NodeGroup.java
@@ -4,15 +4,15 @@ import envoy.api.v2.core.Base.Node;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * {@code NodeGroup} aggregates config resources by a hash of the {@link Node}.
+ * {@code NodeGroup} aggregates config resources by a consistent grouping of {@link Node}s.
  */
 @ThreadSafe
-public interface NodeGroup {
+public interface NodeGroup<T> {
 
   /**
-   * Returns a consistent hash of the given {@link Node}.
+   * Returns a consistent identifier of the given {@link Node}.
    *
    * @param node identifier for the envoy instance that is requesting config
    */
-  String hash(Node node);
+  T hash(Node node);
 }

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -25,20 +25,20 @@ import org.slf4j.LoggerFactory;
  * only the responses for the particular type of the xDS service that the cache serves. Synchronization of multiple
  * caches for different response types is left to the configuration producer.
  */
-public class SimpleCache implements Cache {
+public class SimpleCache<T> implements Cache<T> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SimpleCache.class);
 
-  private final Consumer<String> callback;
-  private final NodeGroup groups;
+  private final Consumer<T> callback;
+  private final NodeGroup<T> groups;
 
   private final Object lock = new Object();
-  private final Map<String, Snapshot> snapshots = new HashMap<>();
-  private final Map<String, Map<Long, Watch>> watches = new HashMap<>();
+  private final Map<T, Snapshot> snapshots = new HashMap<>();
+  private final Map<T, Map<Long, Watch>> watches = new HashMap<>();
 
   private long watchCount;
 
-  public SimpleCache(Consumer<String> callback, NodeGroup groups) {
+  public SimpleCache(Consumer<T> callback, NodeGroup<T> groups) {
     this.callback = callback;
     this.groups = groups;
   }
@@ -47,7 +47,7 @@ public class SimpleCache implements Cache {
    * {@inheritDoc}
    */
   @Override
-  public void setSnapshot(String group, Snapshot snapshot) {
+  public void setSnapshot(T group, Snapshot snapshot) {
     synchronized (lock) {
       // Update the existing entry.
       snapshots.put(group, snapshot);
@@ -69,7 +69,7 @@ public class SimpleCache implements Cache {
   public Watch watch(ResourceType type, Node node, String version, Collection<String> names) {
     Watch watch = new Watch(names, type);
 
-    final String group;
+    final T group;
 
     // Do nothing if group hashing failed.
     try {
@@ -123,7 +123,7 @@ public class SimpleCache implements Cache {
     }
   }
 
-  private void respond(Watch watch, Snapshot snapshot, String group) {
+  private void respond(Watch watch, Snapshot snapshot, T group) {
     Collection<Message> resources = snapshot.resources().get(watch.type());
 
     // Remove clean-up as the watch is discarded immediately
@@ -155,7 +155,7 @@ public class SimpleCache implements Cache {
   }
 
   @VisibleForTesting
-  Map<String, Map<Long, Watch>> watches() {
+  Map<T, Map<Long, Watch>> watches() {
     return watches;
   }
 }

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
@@ -44,7 +44,7 @@ public class SimpleCacheTest {
 
   @Test
   public void invalidNamesListShouldReturnWatcherWithNoResponse() {
-    SimpleCache cache = new SimpleCache(null, new SingleNodeGroup());
+    SimpleCache<String> cache = new SimpleCache<>(null, new SingleNodeGroup());
 
     cache.setSnapshot(SingleNodeGroup.GROUP, SNAPSHOT);
 
@@ -59,7 +59,7 @@ public class SimpleCacheTest {
 
   @Test
   public void watchNullNodeReturnWatcherWithNoResponse() {
-    SimpleCache cache = new SimpleCache(null, new SingleNodeGroup());
+    SimpleCache<String> cache = new SimpleCache<>(null, new SingleNodeGroup());
 
     cache.setSnapshot(SingleNodeGroup.GROUP, SNAPSHOT);
 
@@ -70,7 +70,7 @@ public class SimpleCacheTest {
 
   @Test
   public void successfullyWatchAllResourceTypesWithSetBeforeWatch() {
-    SimpleCache cache = new SimpleCache(null, new SingleNodeGroup());
+    SimpleCache<String> cache = new SimpleCache<>(null, new SingleNodeGroup());
 
     cache.setSnapshot(SingleNodeGroup.GROUP, SNAPSHOT);
 
@@ -90,7 +90,7 @@ public class SimpleCacheTest {
 
   @Test
   public void successfullyWatchAllResourceTypesWithSetAfterWatch() {
-    SimpleCache cache = new SimpleCache(null, new SingleNodeGroup());
+    SimpleCache<String> cache = new SimpleCache<>(null, new SingleNodeGroup());
 
     Map<ResourceType, Watch> watches = Arrays.stream(ResourceType.values())
         .collect(Collectors.toMap(
@@ -110,7 +110,7 @@ public class SimpleCacheTest {
 
   @Test
   public void watchesAreReleasedAfterCancel() {
-    SimpleCache cache = new SimpleCache(null, new SingleNodeGroup());
+    SimpleCache<String> cache = new SimpleCache<>(null, new SingleNodeGroup());
 
     Map<ResourceType, Watch> watches = Arrays.stream(ResourceType.values())
         .collect(Collectors.toMap(
@@ -131,7 +131,7 @@ public class SimpleCacheTest {
     CountDownLatch latch = new CountDownLatch(1);
     AtomicReference<String> receivedKey = new AtomicReference<>();
 
-    SimpleCache cache = new SimpleCache(
+    SimpleCache<String> cache = new SimpleCache<>(
         key -> {
           receivedKey.set(key);
           latch.countDown();
@@ -147,7 +147,7 @@ public class SimpleCacheTest {
     assertThat(receivedKey).hasValue(SingleNodeGroup.GROUP);
   }
 
-  private static class SingleNodeGroup implements NodeGroup {
+  private static class SingleNodeGroup implements NodeGroup<String> {
 
     private static final String GROUP = "node";
 


### PR DESCRIPTION
This allows arbitrary types to be used for group keys instead of just
strings. The main motivation behind this is being able to more easily
use structured data for the group identifier instead of having to encode
it as a string.

This simplifies (and even encourages) using grouping to differentiate
envoy instances, e.g. by what app it's deployed alongside.

Signed-off-by: Snow Pettersen <snowp@squareup.com>