### PR TITLE
cache: Pass in ExecutorService used for async callbacks in SimpleCache

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -47,7 +47,7 @@ public class SimpleCache<T> implements Cache<T> {
   private long watchCount;
 
   /**
-   * Constructs a simple cache that uses {@link ForkJoinPool#commonPool()} to execute async callbacks
+   * Constructs a simple cache that uses {@link ForkJoinPool#commonPool()} to execute async callbacks.
    *
    * @param callback callback invoked when a group is seen for the first time
    * @param groups maps an envoy host to a node group

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -52,7 +52,7 @@ public class SimpleCache<T> implements Cache<T> {
    * @param callback callback invoked when a group is seen for the first time
    * @param groups maps an envoy host to a node group
    */
-  public SimpleCache(Consumer<T> callback, NodeGroup groups) {
+  public SimpleCache(Consumer<T> callback, NodeGroup<T> groups) {
     this(callback, groups, ForkJoinPool.commonPool());
   }
 
@@ -63,7 +63,7 @@ public class SimpleCache<T> implements Cache<T> {
    * @param groups maps an envoy host to a node group
    * @param executorService executor service used to execute async callbacks
    */
-  public SimpleCache(Consumer<T> callback, NodeGroup groups, ExecutorService executorService) {
+  public SimpleCache(Consumer<T> callback, NodeGroup<T> groups, ExecutorService executorService) {
     this.callback = callback;
     this.groups = groups;
     this.executorService = executorService;


### PR DESCRIPTION
This allows passing in the ExecutorService to use instead of always
using the ForkJoinPool. This gives users more control over where the
callback is executed, and also makes it possible to use ExecutorServices
that propagate state to callback threads (e.g. to propagate
trace/logging context).

Signed-off-by: Snow Pettersen <snowp@squareup.com>

cc @mpuncel @nicktrav 