### PR TITLE
cache: Refactor Map usage into Set

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -5,11 +5,12 @@ import com.google.protobuf.Message;
 import envoy.api.v2.core.Base.Node;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,7 +125,7 @@ public class SimpleCache implements Cache {
   }
 
   private void respond(Watch watch, Snapshot snapshot, String group) {
-    Collection<Message> resources = snapshot.resources().get(watch.type());
+    Collection<Message> snapshotResources = snapshot.resources().get(watch.type());
 
     // Remove clean-up as the watch is discarded immediately
     watch.setStop(null);
@@ -132,11 +133,11 @@ public class SimpleCache implements Cache {
     // The request names must match the snapshot names. If they do not, then the watch is never responded, and it is
     // expected that envoy makes another request.
     if (!watch.names().isEmpty()) {
-      Map<String, Boolean> names = watch.names().stream().collect(Collectors.toMap(name -> name, name -> true));
+      Set<String> watchedResourceNames = new HashSet<>(watch.names());
 
-      Optional<String> missingResourceName = resources.stream()
+      Optional<String> missingResourceName = snapshotResources.stream()
           .map(Resources::getResourceName)
-          .filter(n -> !names.containsKey(n))
+          .filter(n -> !watchedResourceNames.contains(n))
           .findFirst();
 
       if (missingResourceName.isPresent()) {
@@ -151,7 +152,7 @@ public class SimpleCache implements Cache {
       }
     }
 
-    watch.valueEmitter().onNext(Response.create(false, resources, snapshot.version()));
+    watch.valueEmitter().onNext(Response.create(false, snapshotResources, snapshot.version()));
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Instead of using Map<T, Boolean> just use a Set instead. This doesn't
affect behavior at all, it's just more idiomatic Java.

Also some variable name renames just to make the code a little bit clearer to read

Signed-off-by: Snow Pettersen <snowp@squareup.com>