### PR TITLE
cache: Add @GuardedBy to clarifiy how thread safety is achieved

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import javax.annotation.concurrent.GuardedBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,9 +34,12 @@ public class SimpleCache implements Cache {
   private final NodeGroup groups;
 
   private final Object lock = new Object();
+  @GuardedBy("lock")
   private final Map<String, Snapshot> snapshots = new HashMap<>();
+  @GuardedBy("lock")
   private final Map<String, Map<Long, Watch>> watches = new HashMap<>();
 
+  @GuardedBy("lock")
   private long watchCount;
 
   public SimpleCache(Consumer<String> callback, NodeGroup groups) {


### PR DESCRIPTION
This just adds @GuardedBy to the mutable fields of SimpleCache to
clarify to readers and static analyzers how we ensure that changes made
to these field are made available across threads.

Signed-off-by: Snow Pettersen <snowp@squareup.com>