### PR TITLE
cache: Make SimpleCache#watches thread safe

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -122,11 +122,7 @@ public class SimpleCache<T> implements Cache<T> {
 
         watch.setStop(() -> {
           synchronized (lock) {
-            Map<Long, Watch> groupWatches = watches.row(group);
-
-            if (groupWatches != null) {
-              groupWatches.remove(id);
-            }
+            watches.remove(group, id);
           }
         });
 

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -1,6 +1,9 @@
 package io.envoyproxy.controlplane.cache;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
 import com.google.protobuf.Message;
 import envoy.api.v2.core.Base.Node;
 import java.util.Collection;
@@ -11,6 +14,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +43,7 @@ public class SimpleCache<T> implements Cache<T> {
   @GuardedBy("lock")
   private final Map<T, Snapshot> snapshots = new HashMap<>();
   @GuardedBy("lock")
-  private final Map<T, Map<Long, Watch>> watches = new HashMap<>();
+  private final Table<T, Long, Watch> watches = HashBasedTable.create();
 
   @GuardedBy("lock")
   private long watchCount;
@@ -58,13 +62,19 @@ public class SimpleCache<T> implements Cache<T> {
       // Update the existing entry.
       snapshots.put(group, snapshot);
 
-      // Trigger existing watches.
-      if (watches().containsKey(group)) {
-        watches().get(group).values().forEach(watch -> respond(watch, snapshot, group));
+      // Trigger existing watches
+      Set<Long> idsToRemove = watches.row(group).entrySet().stream()
+          .map(watchEntry -> {
+            respond(watchEntry.getValue(), snapshot, group);
+            return watchEntry.getKey();
+          })
+          .collect(Collectors.toSet());
 
-        // Discard all watches; the client must request a new watch to receive updates and ACK/NACK.
-        watches().remove(group);
-      }
+      // Discard all watches; the client must request a new watch to receive updates and ACK/NACK.
+      //
+      // Note that the removals have to happen after we're done iterating over the row Map otherwise
+      // we get a java.util.ConcurrentModificationException
+      idsToRemove.forEach(idToRemove -> watches.remove(group, idToRemove));
     }
   }
 
@@ -108,11 +118,11 @@ public class SimpleCache<T> implements Cache<T> {
 
         long id = watchCount;
 
-        watches().computeIfAbsent(group, g -> new HashMap<>()).put(id, watch);
+        watches.put(group, id, watch);
 
         watch.setStop(() -> {
           synchronized (lock) {
-            Map<Long, Watch> groupWatches = watches().get(group);
+            Map<Long, Watch> groupWatches = watches.row(group);
 
             if (groupWatches != null) {
               groupWatches.remove(id);
@@ -161,7 +171,9 @@ public class SimpleCache<T> implements Cache<T> {
   }
 
   @VisibleForTesting
-  Map<T, Map<Long, Watch>> watches() {
-    return watches;
+  Table<T, Long, Watch> watches() {
+    synchronized (lock) {
+      return ImmutableTable.copyOf(watches);
+    }
   }
 }

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
@@ -117,11 +117,11 @@ public class SimpleCacheTest {
             type -> type,
             type -> cache.watch(type, Node.getDefaultInstance(), "", NAMES.get(type))));
 
-    assertThat(cache.watches().get(SingleNodeGroup.GROUP)).hasSize(watches.size());
+    assertThat(cache.watches().row(SingleNodeGroup.GROUP)).hasSize(watches.size());
 
     watches.values().forEach(Watch::cancel);
 
-    assertThat(cache.watches().get(SingleNodeGroup.GROUP)).isEmpty();
+    assertThat(cache.watches().row(SingleNodeGroup.GROUP)).isEmpty();
 
     watches.values().forEach(watch -> assertThat(watch.valueEmitter().isTerminated()).isTrue());
   }


### PR DESCRIPTION
SimpleCache#watches publishes a non-thread safe member of SimpleCache
without synchronization which means that changes made on other threads
are not guaranteed to be visible.

This change synchronizes access to the watches method and makes a
defensive copy of the underlying data. To simplify this I changed the
data structure from `Map<Map<>>` to `Table`, which let's me use
`ImmutableTable.copyOf` to copy the data more easily.

It also changes usages of #watches() internal to the class to reference
the field directly to avoid the cost of a copy.

Signed-off-by: Snow Pettersen <snowp@squareup.com>

This method is just used without synchronization in test right now, so it's probably not a big deal, but I figured it'd make sense to keep the class completely thread safe, even if just to prevent bugs in the future when someone makes this method public and to ensure that we don't get any concurrency issues in test. 

cc @nicktrav 