### PR TITLE
cache: Store node group in StatusInfo instead of node

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/CacheStatusInfo.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/CacheStatusInfo.java
@@ -1,7 +1,6 @@
 package io.envoyproxy.controlplane.cache;
 
 import com.google.common.collect.ImmutableSet;
-import envoy.api.v2.core.Base.Node;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -17,9 +16,9 @@ import javax.annotation.concurrent.ThreadSafe;
  * implementations.
  */
 @ThreadSafe
-public class CacheStatusInfo implements StatusInfo {
+public class CacheStatusInfo<T> implements StatusInfo<T> {
 
-  private final Node node;
+  private final T nodeGroup;
 
   @GuardedBy("lock")
   private final Map<Long, Watch> watches = new HashMap<>();
@@ -31,8 +30,8 @@ public class CacheStatusInfo implements StatusInfo {
   @GuardedBy("lock")
   private long lastWatchRequestTime;
 
-  CacheStatusInfo(Node node) {
-    this.node = node;
+  public CacheStatusInfo(T nodeGroup) {
+    this.nodeGroup = nodeGroup;
   }
 
   /**
@@ -53,8 +52,8 @@ public class CacheStatusInfo implements StatusInfo {
    * {@inheritDoc}
    */
   @Override
-  public Node node() {
-    return node;
+  public T nodeGroup() {
+    return nodeGroup;
   }
 
   /**

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -37,7 +37,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
   @GuardedBy("lock")
   private final Map<T, Snapshot> snapshots = new HashMap<>();
   @GuardedBy("lock")
-  private final Map<T, CacheStatusInfo> statuses = new HashMap<>();
+  private final Map<T, CacheStatusInfo<T>> statuses = new HashMap<>();
 
   @GuardedBy("lock")
   private long watchCount;
@@ -63,7 +63,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
     writeLock.lock();
 
     try {
-      CacheStatusInfo status = statuses.computeIfAbsent(group, g -> new CacheStatusInfo(request.getNode()));
+      CacheStatusInfo<T> status = statuses.computeIfAbsent(group, g -> new CacheStatusInfo<>(group));
 
       status.setLastWatchRequestTime(System.currentTimeMillis());
 
@@ -121,7 +121,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
       // Update the existing snapshot entry.
       snapshots.put(group, snapshot);
 
-      CacheStatusInfo status = statuses.get(group);
+      CacheStatusInfo<T> status = statuses.get(group);
 
       if (status == null) {
         return;

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/StatusInfo.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/StatusInfo.java
@@ -5,7 +5,7 @@ import envoy.api.v2.core.Base.Node;
 /**
  * {@code StatusInfo} tracks the state for remote envoy nodes.
  */
-public interface StatusInfo {
+public interface StatusInfo<T> {
 
   /**
    * Returns the timestamp of the last discovery watch request.
@@ -13,9 +13,9 @@ public interface StatusInfo {
   long lastWatchRequestTime();
 
   /**
-   * Returns the node metadata.
+   * Returns the node grouping represented by this status, generated via {@link NodeGroup#hash(Node)}.
    */
-  Node node();
+  T nodeGroup();
 
   /**
    * Returns the number of open watches.

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/CacheStatusInfoTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/CacheStatusInfoTest.java
@@ -14,17 +14,17 @@ import org.junit.Test;
 public class CacheStatusInfoTest {
 
   @Test
-  public void nodeReturnsExpectedInstance() {
+  public void nodeGroupReturnsExpectedGroup() {
     Node node = Node.newBuilder().setId(UUID.randomUUID().toString()).build();
 
-    CacheStatusInfo info = new CacheStatusInfo(node);
+    CacheStatusInfo<Node> info = new CacheStatusInfo<>(node);
 
-    assertThat(info.node()).isSameAs(node);
+    assertThat(info.nodeGroup()).isSameAs(node);
   }
 
   @Test
   public void lastWatchRequestTimeReturns0IfNotSet() {
-    CacheStatusInfo info = new CacheStatusInfo(Node.getDefaultInstance());
+    CacheStatusInfo<Node> info = new CacheStatusInfo<>(Node.getDefaultInstance());
 
     assertThat(info.lastWatchRequestTime()).isZero();
   }
@@ -33,7 +33,7 @@ public class CacheStatusInfoTest {
   public void lastWatchRequestTimeReturnsExpectedValueIfSet() {
     final long lastWatchRequestTime = ThreadLocalRandom.current().nextLong(10000, 50000);
 
-    CacheStatusInfo info = new CacheStatusInfo(Node.getDefaultInstance());
+    CacheStatusInfo<Node> info = new CacheStatusInfo<>(Node.getDefaultInstance());
 
     info.setLastWatchRequestTime(lastWatchRequestTime);
 
@@ -45,7 +45,7 @@ public class CacheStatusInfoTest {
     final long watchId1 = ThreadLocalRandom.current().nextLong(10000, 50000);
     final long watchId2 = ThreadLocalRandom.current().nextLong(50000, 100000);
 
-    CacheStatusInfo info = new CacheStatusInfo(Node.getDefaultInstance());
+    CacheStatusInfo<Node> info = new CacheStatusInfo<>(Node.getDefaultInstance());
 
     assertThat(info.numWatches()).isZero();
 
@@ -70,7 +70,7 @@ public class CacheStatusInfoTest {
     final long watchId1 = ThreadLocalRandom.current().nextLong(10000, 50000);
     final long watchId2 = ThreadLocalRandom.current().nextLong(50000, 100000);
 
-    CacheStatusInfo info = new CacheStatusInfo(Node.getDefaultInstance());
+    CacheStatusInfo<Node> info = new CacheStatusInfo<>(Node.getDefaultInstance());
 
     info.setWatch(watchId1, new Watch(DiscoveryRequest.getDefaultInstance()));
     info.setWatch(watchId2, new Watch(DiscoveryRequest.getDefaultInstance()));
@@ -88,7 +88,7 @@ public class CacheStatusInfoTest {
   public void testConcurrentSetWatchAndRemove() {
     final int watchCount = 50;
 
-    CacheStatusInfo info = new CacheStatusInfo(Node.getDefaultInstance());
+    CacheStatusInfo<Node> info = new CacheStatusInfo<>(Node.getDefaultInstance());
 
     Collection<Long> watchIds = LongStream.range(0, watchCount).boxed().collect(Collectors.toList());
 


### PR DESCRIPTION
Returning the `Node` in the `StatusInfo` doesn't really make sense because it may not be accurate, depending on the `NodeGroup` implementation. It essentially just returns the first `Node` that hashed to a given group.

Signed-off-by: Joey Bratton <jbratton@salesforce.com>