### PR TITLE
cache: Add SimpleCache#getSnapshot

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -110,6 +110,19 @@ public class SimpleCache<T> implements SnapshotCache<T> {
   /**
    * {@inheritDoc}
    */
+  @Override public Snapshot getSnapshot(T group) {
+    readLock.lock();
+
+    try {
+      return snapshots.get(group);
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public void setSnapshot(T group, Snapshot snapshot) {
     writeLock.lock();
@@ -144,30 +157,6 @@ public class SimpleCache<T> implements SnapshotCache<T> {
       });
     } finally {
       writeLock.unlock();
-    }
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override public Snapshot getSnapshot(T group) {
-    readLock.lock();
-
-    try {
-      Snapshot snapshot = snapshots.get(group);
-
-      // Return a copy of the collections to prevent external modification of the actual snapshot
-      return Snapshot.create(
-          snapshot.clusters().resources().values(),
-          snapshot.clusters().version(),
-          snapshot.endpoints().resources().values(),
-          snapshot.endpoints().version(),
-          snapshot.listeners().resources().values(),
-          snapshot.listeners().version(),
-          snapshot.routes().resources().values(),
-          snapshot.routes().version());
-    } finally {
-      readLock.unlock();
     }
   }
 

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -150,6 +150,30 @@ public class SimpleCache<T> implements SnapshotCache<T> {
   /**
    * {@inheritDoc}
    */
+  @Override public Snapshot getSnapshot(T group) {
+    readLock.lock();
+
+    try {
+      Snapshot snapshot = snapshots.get(group);
+
+      // Return a copy of the collections to prevent external modification of the actual snapshot
+      return Snapshot.create(
+          snapshot.clusters().resources().values(),
+          snapshot.clusters().version(),
+          snapshot.endpoints().resources().values(),
+          snapshot.endpoints().version(),
+          snapshot.listeners().resources().values(),
+          snapshot.listeners().version(),
+          snapshot.routes().resources().values(),
+          snapshot.routes().version());
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public StatusInfo statusInfo(T group) {
     readLock.lock();

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SnapshotCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SnapshotCache.java
@@ -3,6 +3,14 @@ package io.envoyproxy.controlplane.cache;
 public interface SnapshotCache<T> extends Cache<T> {
 
   /**
+   * Returns the most recently set {@link Snapshot} for the given node group.
+   *
+   * @param group group identifier
+   * @return latest snapshot
+   */
+  Snapshot getSnapshot(T group);
+
+  /**
    * Set the {@link Snapshot} for the given node group. Snapshots should have distinct versions and be internally
    * consistent (i.e. all referenced resources must be included in the snapshot).
    *
@@ -10,12 +18,4 @@ public interface SnapshotCache<T> extends Cache<T> {
    * @param snapshot a versioned collection of node config data
    */
   void setSnapshot(T group, Snapshot snapshot);
-
-  /**
-   * Returns the most recently set {@link Snapshot} for the given node group.
-   *
-   * @param group group identifier
-   * @return latest snapshot
-   */
-  Snapshot getSnapshot(T group);
 }

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SnapshotCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SnapshotCache.java
@@ -10,4 +10,12 @@ public interface SnapshotCache<T> extends Cache<T> {
    * @param snapshot a versioned collection of node config data
    */
   void setSnapshot(T group, Snapshot snapshot);
+
+  /**
+   * Returns the most recently set {@link Snapshot} for the given node group.
+   *
+   * @param group group identifier
+   * @return latest snapshot
+   */
+  Snapshot getSnapshot(T group);
 }

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
@@ -216,6 +216,15 @@ public class SimpleCacheTest {
     watches.values().forEach(watch -> assertThat(((EmitterProcessor<Response>) watch.value()).isTerminated()).isTrue());
   }
 
+  @Test
+  public void getSnapshot() {
+    SimpleCache<String> cache = new SimpleCache<>(new SingleNodeGroup());
+
+    cache.setSnapshot(SingleNodeGroup.GROUP, SNAPSHOT1);
+
+    assertThat(cache.getSnapshot(SingleNodeGroup.GROUP)).isEqualTo(SNAPSHOT1);
+  }
+
   private static void assertThatWatchIsOpenWithNoPendingResponses(Watch watch) {
     assertThat(((EmitterProcessor<Response>) watch.value()).getPending()).isZero();
     assertThat(((EmitterProcessor<Response>) watch.value()).isTerminated()).isFalse();


### PR DESCRIPTION
This adds a simple getter to SimpleCache that allows retrieving the
current snapshot for a given NodeGroup. Querying the current state of a
group is useful for debugging purposes, test and also for cases where
you might want to inspect the current state before generating a new
snapshot.

Signed-off-by: Snow Pettersen <snowp@squareup.com>