### PR TITLE
server: Don't log an error when stream canceled

### DIFF
--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
@@ -188,7 +188,10 @@ public class DiscoveryServer {
 
       @Override
       public void onError(Throwable t) {
-        LOGGER.error("[{}] stream closed with error", streamId, t);
+        if (!Status.fromThrowable(t).equals(Status.CANCELLED)) {
+          LOGGER.error("[{}] stream closed with error", streamId, t);
+        }
+
         callbacks.onStreamCloseWithError(streamId, defaultTypeUrl, t);
         responseObserver.onError(Status.fromThrowable(t).asException());
         cancel();


### PR DESCRIPTION
The stream is canceled when the client shuts down without properly
terminating the gRPC stream. This is not really an error (c.f.
https://github.com/grpc/grpc-java/issues/4232) and logging an error here
means a lot of log noise when envoys shut down.

Signed-off-by: Snow Pettersen <snowp@squareup.com>