### PR TITLE
cache: add SnapshotCache#clearSnapshot

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -53,6 +53,31 @@ public class SimpleCache<T> implements SnapshotCache<T> {
   /**
    * {@inheritDoc}
    */
+  @Override public boolean clearSnapshot(T group) {
+    writeLock.lock();
+
+    try {
+      CacheStatusInfo<T> status = statuses.get(group);
+
+      // If we don't know about this group, do nothing.
+      if (status != null && status.numWatches() > 0) {
+        LOGGER.warn("tried to clear snapshot for group with existing watches, group={}", group);
+
+        return false;
+      }
+
+      statuses.remove(group);
+      snapshots.remove(group);
+
+      return true;
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public Watch createWatch(boolean ads, DiscoveryRequest request) {
     T group = groups.hash(request.getNode());

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SnapshotCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SnapshotCache.java
@@ -3,6 +3,20 @@ package io.envoyproxy.controlplane.cache;
 public interface SnapshotCache<T> extends Cache<T> {
 
   /**
+   * Clears the most recently set {@link Snapshot} and associated metadata for the given node group.
+   *
+   * <p>Should only be called when the {@link Snapshot} will no longer be needed, e.g. when there
+   * are no open watches for the group.
+   *
+   * <p>Implementations are free to ignore this call should it possibly leave the cache in a bad
+   * state, e.g. causing watches to hang waiting for {@link Snapshot} options that will never happen.
+   *
+   * @param group group identifier
+   * @return true if the snapshot was cleared, false otherwise
+   */
+  boolean clearSnapshot(T group);
+
+  /**
    * Returns the most recently set {@link Snapshot} for the given node group.
    *
    * @param group group identifier

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
@@ -242,7 +242,7 @@ public class SimpleCacheTest {
 
     cache.setSnapshot(SingleNodeGroup.GROUP, SNAPSHOT1);
 
-    Watch watch = cache.createWatch(ADS, DiscoveryRequest.newBuilder()
+    final Watch watch = cache.createWatch(ADS, DiscoveryRequest.newBuilder()
         .setNode(Node.getDefaultInstance())
         .setTypeUrl("")
         .build());


### PR DESCRIPTION
Adds a method to SnapshotCache that allows clearing out a Snapshot and
associated metadata. This allows clearing out cache entries that are
known to be no longer needed as a way to keep the size of the cache in
check.

Signed-off-by: Snow Pettersen <snowp@squareup.com>