### PR TITLE
deps: Downgrade guava to 20.0 and misc minor dep updates

### DIFF
--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -13,6 +13,12 @@
     <dependencies>
         <dependency>
             <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value-annotations</artifactId>
+            <version>${auto-value.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
             <version>${auto-value.version}</version>
             <scope>provided</scope>

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SnapshotResources.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SnapshotResources.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Message;
 import java.util.Map;
+import java.util.stream.Collector;
 import java.util.stream.StreamSupport;
 
 @AutoValue
@@ -19,7 +20,12 @@ public abstract class SnapshotResources<T extends Message> {
   public static <T extends Message> SnapshotResources<T> create(Iterable<T> resources, String version) {
     return new AutoValue_SnapshotResources<>(
         StreamSupport.stream(resources.spliterator(), false)
-            .collect(ImmutableMap.toImmutableMap(Resources::getResourceName, r -> r)),
+            .collect(
+                Collector.of(
+                    ImmutableMap.Builder<String, T>::new,
+                    (b, e) -> b.put(Resources.getResourceName(e), e),
+                    (b1, b2) -> b1.putAll(b2.build()),
+                    ImmutableMap.Builder::build)),
         version);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,17 +22,17 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Dependency Versions -->
-        <assertj.version>3.9.0</assertj.version>
-        <auto-value.version>1.5.3</auto-value.version>
+        <assertj.version>3.10.0</assertj.version>
+        <auto-value.version>1.6</auto-value.version>
         <awaitility.version>3.1.0</awaitility.version>
         <checkstyle.version>8.8</checkstyle.version>
         <grpc.version>1.12.0</grpc.version>
-        <guava.version>24.1-jre</guava.version>
+        <guava.version>20.0</guava.version>
         <junit.version>4.12</junit.version>
-        <reactor.version>3.1.3.RELEASE</reactor.version>
-        <rest-assured.version>3.0.7</rest-assured.version>
+        <reactor.version>3.1.7.RELEASE</reactor.version>
+        <rest-assured.version>3.1.0</rest-assured.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <testcontainers.version>1.7.0</testcontainers.version>
+        <testcontainers.version>1.7.3</testcontainers.version>
 
         <!-- Maven Plugin Versions -->
         <jacoco-maven-plugin.version>0.8.0</jacoco-maven-plugin.version>


### PR DESCRIPTION
The lib will still work fine with newer guavas, but dropping the minimum required guava to 20.0 allows us to play nicer with older libs.