### PR TITLE
cache/server: keep track of acked responses and respond to new hints

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/ConfigWatcher.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/ConfigWatcher.java
@@ -1,6 +1,7 @@
 package io.envoyproxy.controlplane.cache;
 
 import envoy.api.v2.Discovery.DiscoveryRequest;
+import java.util.Set;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -16,6 +17,7 @@ public interface ConfigWatcher {
    *
    * @param ads is the watch for an ADS request?
    * @param request the discovery request (node, names, etc.) to use to generate the watch
+   * @param knownResourceNames resources that are already known to the caller
    */
-  Watch createWatch(boolean ads, DiscoveryRequest request);
+  Watch createWatch(boolean ads, DiscoveryRequest request, Set<String> knownResourceNames);
 }

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -98,22 +98,24 @@ public class SimpleCache<T> implements SnapshotCache<T> {
 
       Watch watch = new Watch(ads, request);
 
-      HashSet<String> requestedResources = new HashSet<>(request.getResourceNamesList());
-      // If the request is asking for resources we haven't sent to the proxy yet, see if we have
-      // additional resources
-      if (snapshot != null && !knownResourceNames.equals(requestedResources)) {
-        Sets.SetView<String> newResourceHints =
-            Sets.difference(requestedResources, knownResourceNames);
+      if (snapshot != null) {
+        HashSet<String> requestedResources = new HashSet<>(request.getResourceNamesList());
+        // If the request is asking for resources we haven't sent to the proxy yet, see if we have
+        // additional resources
+        if (!knownResourceNames.equals(requestedResources)) {
+          Sets.SetView<String> newResourceHints =
+              Sets.difference(requestedResources, knownResourceNames);
 
-        // If any of the newly requested resources are in the snapshot respond immediately. If not
-        // we'll fall back to version comparisons.
-        if (snapshot.resources(request.getTypeUrl())
-            .keySet()
-            .stream()
-            .anyMatch(newResourceHints::contains)) {
-          respond(watch, snapshot, group);
+          // If any of the newly requested resources are in the snapshot respond immediately. If not
+          // we'll fall back to version comparisons.
+          if (snapshot.resources(request.getTypeUrl())
+              .keySet()
+              .stream()
+              .anyMatch(newResourceHints::contains)) {
+            respond(watch, snapshot, group);
 
-          return watch;
+            return watch;
+          }
         }
       }
 

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -1,12 +1,15 @@
 package io.envoyproxy.controlplane.cache;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
 import envoy.api.v2.Discovery.DiscoveryRequest;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -80,7 +83,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
    * {@inheritDoc}
    */
   @Override
-  public Watch createWatch(boolean ads, DiscoveryRequest request) {
+  public Watch createWatch(boolean ads, DiscoveryRequest request, Set<String> knownResourceNames) {
     T group = groups.hash(request.getNode());
 
     writeLock.lock();
@@ -94,6 +97,25 @@ public class SimpleCache<T> implements SnapshotCache<T> {
       String version = snapshot == null ? "" : snapshot.version(request.getTypeUrl());
 
       Watch watch = new Watch(ads, request);
+
+      HashSet<String> requestedResources = new HashSet<>(request.getResourceNamesList());
+      // If the request is asking for resources we haven't sent to the proxy yet, see if we have
+      // additional resources
+      if (snapshot != null && !knownResourceNames.equals(requestedResources)) {
+        Sets.SetView<String> newResourceHints =
+            Sets.difference(requestedResources, knownResourceNames);
+
+        // If any of the newly requested resources are in the snapshot respond immediately. If not
+        // we'll fall back to version comparisons.
+        if (snapshot.resources(request.getTypeUrl())
+            .keySet()
+            .stream()
+            .anyMatch(newResourceHints::contains)) {
+          respond(watch, snapshot, group);
+
+          return watch;
+        }
+      }
 
       // If the requested version is up-to-date or missing a response, leave an open watch.
       if (snapshot == null || request.getVersionInfo().equals(version)) {

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
@@ -129,12 +129,10 @@ public class DiscoveryServer {
 
     return new StreamObserver<DiscoveryRequest>() {
 
-      private final Map<String, Watch> watches =
-          new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
+      private final Map<String, Watch> watches = new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
       private final Map<String, DiscoveryResponse> latestResponse =
           new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
-      private final Map<String, Set<String>> ackedResources =
-          new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
+      private final Map<String, Set<String>> ackedResources = new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
 
       private AtomicLong streamNonce = new AtomicLong();
 

--- a/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerTest.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerTest.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
@@ -681,7 +682,7 @@ public class DiscoveryServerTest {
     }
 
     @Override
-    public Watch createWatch(boolean ads, DiscoveryRequest request) {
+    public Watch createWatch(boolean ads, DiscoveryRequest request, Set<String> knownResources) {
       counts.put(request.getTypeUrl(), counts.getOrDefault(request.getTypeUrl(), 0) + 1);
 
       Watch watch = new Watch(ads, request);


### PR DESCRIPTION
This makes the DiscoveryServer keep track of the latest acked response,
allowing it to respond to DiscoveryRequests that come in for the
currently acked version but with new resource hints. This reduces the
need for odering the xDs responses: if a CDS response adds a cluster but
we've already sent the EDS response for the current version, Envoy will
be able to retreive the latest version by updating the resource hint and
receiving a new response.

Testing that the DiscoveryService part proved pretty tricky due to all the concurrency
involved in the existing tests, so I'm open to suggestions to how this should be tested.

Signed-off-by: Snow Pettersen <snowp@squareup.com>