### PR TITLE
cache: remove cache lock in cancel callback

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -110,15 +110,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
 
         status.setWatch(watchId, watch);
 
-        watch.setStop(() -> {
-          writeLock.lock();
-
-          try {
-            status.removeWatch(watchId);
-          } finally {
-            writeLock.unlock();
-          }
-        });
+        watch.setStop(() -> status.removeWatch(watchId));
 
         return watch;
       }


### PR DESCRIPTION
The CacheStatusInfo#cancel method is already guarded by a mutex, so the
additional locking on the entire SnapshotCache seems to be unnecessary.
Since we're only mutating the CacheStatusInfo and not the SnapshotCache,
the write lock seems like overkill. This should hopefully reduce some of the 
lock contention.

Let me know if i'm missing something obvious that makes this lock necessary.

Signed-off-by: Snow Pettersen <snowp@squareup.com>