### PR TITLE
server: ensure that watches are canceled during connection close

### DIFF
--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
@@ -207,17 +207,24 @@ public class DiscoveryServer {
           LOGGER.error("[{}] stream closed with error", streamId, t);
         }
 
-        callbacks.onStreamCloseWithError(streamId, defaultTypeUrl, t);
-        responseObserver.onError(Status.fromThrowable(t).asException());
-        cancel();
+        try {
+          callbacks.onStreamCloseWithError(streamId, defaultTypeUrl, t);
+          responseObserver.onError(Status.fromThrowable(t).asException());
+        } finally {
+          cancel();
+        }
       }
 
       @Override
       public void onCompleted() {
         LOGGER.info("[{}] stream closed", streamId);
-        callbacks.onStreamClose(streamId, defaultTypeUrl);
-        responseObserver.onCompleted();
-        cancel();
+
+        try {
+          callbacks.onStreamClose(streamId, defaultTypeUrl);
+          responseObserver.onCompleted();
+        } finally {
+          cancel();
+        }
       }
 
       private void cancel() {


### PR DESCRIPTION
Should any of the callbacks fail, we'll end up not properly canceling
the snapshot watches, causing them to live forever. This PR adds a
finally block to ensure that cancel is always called.