### PR TITLE
test: update ConfigSource to no longer use deprecated config

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/TestResources.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/TestResources.java
@@ -19,6 +19,8 @@ import envoy.api.v2.core.ConfigSourceOuterClass.AggregatedConfigSource;
 import envoy.api.v2.core.ConfigSourceOuterClass.ApiConfigSource;
 import envoy.api.v2.core.ConfigSourceOuterClass.ApiConfigSource.ApiType;
 import envoy.api.v2.core.ConfigSourceOuterClass.ConfigSource;
+import envoy.api.v2.core.GrpcServiceOuterClass.GrpcService;
+import envoy.api.v2.core.GrpcServiceOuterClass.GrpcService.EnvoyGrpc;
 import envoy.api.v2.endpoint.EndpointOuterClass.Endpoint;
 import envoy.api.v2.endpoint.EndpointOuterClass.LbEndpoint;
 import envoy.api.v2.endpoint.EndpointOuterClass.LocalityLbEndpoints;
@@ -120,7 +122,9 @@ public class TestResources {
         : ConfigSource.newBuilder()
             .setApiConfigSource(ApiConfigSource.newBuilder()
                 .setApiType(ApiType.GRPC)
-                .addClusterNames(XDS_CLUSTER))
+                .addGrpcServices(GrpcService.newBuilder()
+                    .setEnvoyGrpc(EnvoyGrpc.newBuilder()
+                        .setClusterName(XDS_CLUSTER))))
             .build();
 
     HttpConnectionManager manager = HttpConnectionManager.newBuilder()

--- a/server/src/test/resources/envoy/ads.config.yaml
+++ b/server/src/test/resources/envoy/ads.config.yaml
@@ -5,8 +5,9 @@ admin:
 dynamic_resources:
   ads_config:
     api_type: GRPC
-    cluster_names:
-    - ads_cluster
+    grpc_services:
+      envoy_grpc:
+        cluster_name: ads_cluster
   cds_config:
     ads: {}
   lds_config:

--- a/server/src/test/resources/envoy/xds.config.yaml
+++ b/server/src/test/resources/envoy/xds.config.yaml
@@ -6,13 +6,15 @@ dynamic_resources:
   cds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names:
-      - xds_cluster
+      grpc_services:
+        envoy_grpc:
+          cluster_name: xds_cluster
   lds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names:
-      - xds_cluster
+      grpc_services:
+        envoy_grpc:
+          cluster_name: xds_cluster
 node:
   cluster: test-cluster
   id: test-id


### PR DESCRIPTION
`cluster_names` is deprecated and should no longer be specified. Latest
docker image is failing because of this on master.

[testcontainers-netty-1-2] INFO 🐳 [envoyproxy/envoy-alpine:latest] - STDERR: [2018-07-10 16:40:01.979][18][critical][main] source/server/server.cc:78] error initializing configuration '/tmp/tmp.EjhlgN/envoy.yaml': envoy::api::v2::core::ConfigSource::GRPC must not have a cluster name specified.