### PR TITLE
cache: add overload for getResourceName(Any)

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/Resources.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/Resources.java
@@ -4,7 +4,9 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManagerOuterClass.HttpConnectionManager.RouteSpecifierCase.RDS;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.Struct;
@@ -19,6 +21,7 @@ import envoy.api.v2.listener.Listener.FilterChain;
 import envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManagerOuterClass.HttpConnectionManager;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +46,13 @@ public class Resources {
       LISTENER_TYPE_URL,
       ROUTE_TYPE_URL);
 
+  public static final Map<String, Class<? extends Message>> RESOURCE_TYPE_BY_URL = ImmutableMap.of(
+      CLUSTER_TYPE_URL, Cluster.class,
+      ENDPOINT_TYPE_URL, ClusterLoadAssignment.class,
+      LISTENER_TYPE_URL, Listener.class,
+      ROUTE_TYPE_URL, RouteConfiguration.class
+      );
+
   /**
    * Returns the name of the given resource message.
    *
@@ -66,6 +76,20 @@ public class Resources {
     }
 
     return "";
+  }
+
+  /**
+   * Returns the name of the given resource message.
+   *
+   * @param anyResource the resource message
+   * @throws RuntimeException if the passed Any doesn't correspond to an xDS resource
+   */
+  public static String getResourceName(Any anyResource) {
+    try {
+      return getResourceName(anyResource.unpack(RESOURCE_TYPE_BY_URL.get(anyResource.getTypeUrl())));
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/Resources.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/Resources.java
@@ -3,6 +3,7 @@ package io.envoyproxy.controlplane.cache;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManagerOuterClass.HttpConnectionManager.RouteSpecifierCase.RDS;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -85,8 +86,11 @@ public class Resources {
    * @throws RuntimeException if the passed Any doesn't correspond to an xDS resource
    */
   public static String getResourceName(Any anyResource) {
+    Class<? extends Message> clazz = RESOURCE_TYPE_BY_URL.get(anyResource.getTypeUrl());
+    Preconditions.checkNotNull(clazz, "cannot unpack non-xDS message type");
+
     try {
-      return getResourceName(anyResource.unpack(RESOURCE_TYPE_BY_URL.get(anyResource.getTypeUrl())));
+      return getResourceName(anyResource.unpack(clazz));
     } catch (InvalidProtocolBufferException e) {
       throw new RuntimeException(e);
     }

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/ResourcesTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/ResourcesTest.java
@@ -1,10 +1,12 @@
 package io.envoyproxy.controlplane.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import com.google.type.Color;
 import envoy.api.v2.Cds.Cluster;
@@ -51,6 +53,13 @@ public class ResourcesTest {
     Message message = Color.newBuilder().build();
 
     assertThat(Resources.getResourceName(message)).isEmpty();
+  }
+
+  @Test
+  public void getResourceNameAnyThrowsOnBadClass() {
+    assertThatThrownBy(() -> Resources.getResourceName(Any.newBuilder().setTypeUrl("garbage").build()))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("cannot unpack");
   }
 
   @Test


### PR DESCRIPTION
In DiscoveryServer we use this method to get the resource names of acked
resources. The type of the passed in object is Any, so `getResourceName(Message)`
responds with `""` since the message doesn't match any of the xds resources. This
adds an overload which will unpack the Any message to the appropriate
Message before determining the resource name.

Added a test that ensures the right resources names are persisted (should have done 
this in the original PR...).

This doesn't seem to always cause issues, but when it does it blasts Envoys with 
updates. We had to roll back our deployment of 0.1.7 because of this.

Signed-off-by: Snow Pettersen <snowp@squareup.com>