### PR TITLE
cache: Drop reactor, synchronously call watch's response handler

### DIFF
--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -37,12 +37,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-core</artifactId>
-            <version>${reactor.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/ConfigWatcher.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/ConfigWatcher.java
@@ -2,6 +2,7 @@ package io.envoyproxy.controlplane.cache;
 
 import envoy.api.v2.Discovery.DiscoveryRequest;
 import java.util.Set;
+import java.util.function.Consumer;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -18,6 +19,11 @@ public interface ConfigWatcher {
    * @param ads is the watch for an ADS request?
    * @param request the discovery request (node, names, etc.) to use to generate the watch
    * @param knownResourceNames resources that are already known to the caller
+   * @param responseConsumer the response handler, used to process outgoing response messages
    */
-  Watch createWatch(boolean ads, DiscoveryRequest request, Set<String> knownResourceNames);
+  Watch createWatch(
+      boolean ads,
+      DiscoveryRequest request,
+      Set<String> knownResourceNames,
+      Consumer<Response> responseConsumer);
 }

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -279,6 +279,15 @@ public class SimpleCache<T> implements SnapshotCache<T> {
         snapshotResources,
         version);
 
-    watch.respond(response);
+    try {
+      watch.respond(response);
+    } catch (WatchCancelledException e) {
+      LOGGER.error(
+          "failed to respond for {} from node {} at version {} with version {} because watch was already cancelled",
+          watch.request().getTypeUrl(),
+          group,
+          watch.request().getVersionInfo(),
+          version);
+    }
   }
 }

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/Watch.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/Watch.java
@@ -67,12 +67,14 @@ public class Watch {
    * Sends the given response to the watch's response handler.
    *
    * @param response the response to be handled
+   * @throws WatchCancelledException if the watch has already been cancelled
    */
-  public void respond(Response response) {
-    // TODO: Should trying to respond after cancellation be an error state?
-    if (!isCancelled()) {
-      responseConsumer.accept(response);
+  public void respond(Response response) throws WatchCancelledException {
+    if (isCancelled()) {
+      throw new WatchCancelledException();
     }
+
+    responseConsumer.accept(response);
   }
 
   /**

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/WatchCancelledException.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/WatchCancelledException.java
@@ -1,0 +1,12 @@
+package io.envoyproxy.controlplane.cache;
+
+/**
+ * {@code WatchCancelledException} indicates that an operation cannot be performed because the watch has already been
+ * cancelled.
+ */
+public class WatchCancelledException extends Exception {
+
+  public WatchCancelledException() {
+    super();
+  }
+}

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/CacheStatusInfoTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/CacheStatusInfoTest.java
@@ -50,12 +50,12 @@ public class CacheStatusInfoTest {
 
     assertThat(info.numWatches()).isZero();
 
-    info.setWatch(watchId1, new Watch(ads, DiscoveryRequest.getDefaultInstance()));
+    info.setWatch(watchId1, new Watch(ads, DiscoveryRequest.getDefaultInstance(), r -> { }));
 
     assertThat(info.numWatches()).isEqualTo(1);
     assertThat(info.watchIds()).containsExactlyInAnyOrder(watchId1);
 
-    info.setWatch(watchId2, new Watch(ads, DiscoveryRequest.getDefaultInstance()));
+    info.setWatch(watchId2, new Watch(ads, DiscoveryRequest.getDefaultInstance(), r -> { }));
 
     assertThat(info.numWatches()).isEqualTo(2);
     assertThat(info.watchIds()).containsExactlyInAnyOrder(watchId1, watchId2);
@@ -74,8 +74,8 @@ public class CacheStatusInfoTest {
 
     CacheStatusInfo<Node> info = new CacheStatusInfo<>(Node.getDefaultInstance());
 
-    info.setWatch(watchId1, new Watch(ads, DiscoveryRequest.getDefaultInstance()));
-    info.setWatch(watchId2, new Watch(ads, DiscoveryRequest.getDefaultInstance()));
+    info.setWatch(watchId1, new Watch(ads, DiscoveryRequest.getDefaultInstance(), r -> { }));
+    info.setWatch(watchId2, new Watch(ads, DiscoveryRequest.getDefaultInstance(), r -> { }));
 
     assertThat(info.numWatches()).isEqualTo(2);
     assertThat(info.watchIds()).containsExactlyInAnyOrder(watchId1, watchId2);
@@ -96,7 +96,7 @@ public class CacheStatusInfoTest {
     Collection<Long> watchIds = LongStream.range(0, watchCount).boxed().collect(Collectors.toList());
 
     watchIds.parallelStream().forEach(watchId -> {
-      Watch watch = new Watch(ads, DiscoveryRequest.getDefaultInstance());
+      Watch watch = new Watch(ads, DiscoveryRequest.getDefaultInstance(), r -> { });
 
       info.setWatch(watchId, watch);
     });

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/WatchTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/WatchTest.java
@@ -1,6 +1,8 @@
 package io.envoyproxy.controlplane.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableList;
 import envoy.api.v2.Discovery.DiscoveryRequest;
@@ -78,12 +80,16 @@ public class WatchTest {
 
     Watch watch = new Watch(ads, DiscoveryRequest.getDefaultInstance(), responses::add);
 
-    watch.respond(response1);
-    watch.respond(response2);
+    try {
+      watch.respond(response1);
+      watch.respond(response2);
+    } catch (WatchCancelledException e) {
+      fail("watch should not be cancelled", e);
+    }
 
     watch.cancel();
 
-    watch.respond(response3);
+    assertThatThrownBy(() -> watch.respond(response3)).isInstanceOf(WatchCancelledException.class);
 
     assertThat(responses).containsExactly(response1, response2);
   }

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/WatchTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/WatchTest.java
@@ -2,11 +2,14 @@ package io.envoyproxy.controlplane.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import envoy.api.v2.Discovery.DiscoveryRequest;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
-import reactor.core.publisher.EmitterProcessor;
 
 public class WatchTest {
 
@@ -14,41 +17,74 @@ public class WatchTest {
   public void adsReturnsGivenValue() {
     final boolean ads = ThreadLocalRandom.current().nextBoolean();
 
-    Watch watch = new Watch(ads, DiscoveryRequest.getDefaultInstance());
+    Watch watch = new Watch(ads, DiscoveryRequest.getDefaultInstance(), r -> { });
 
     assertThat(watch.ads()).isEqualTo(ads);
   }
 
   @Test
-  public void cancelTerminatesResponseStream() {
+  public void isCancelledTrueAfterCancel() {
     final boolean ads = ThreadLocalRandom.current().nextBoolean();
 
-    Watch watch = new Watch(ads, DiscoveryRequest.getDefaultInstance());
+    Watch watch = new Watch(ads, DiscoveryRequest.getDefaultInstance(), r -> { });
 
-    assertThat(((EmitterProcessor<Response>) watch.value()).isTerminated()).isFalse();
+    assertThat(watch.isCancelled()).isFalse();
 
     watch.cancel();
 
-    assertThat(((EmitterProcessor<Response>) watch.value()).isTerminated()).isTrue();
+    assertThat(watch.isCancelled()).isTrue();
   }
 
   @Test
-  public void cancelWithStopTerminatesResponseStreamAndCallsStop() {
+  public void cancelWithStopCallsStop() {
     final boolean ads = ThreadLocalRandom.current().nextBoolean();
 
-    AtomicInteger count = new AtomicInteger();
+    AtomicInteger stopCount = new AtomicInteger();
 
-    Watch watch = new Watch(ads, DiscoveryRequest.getDefaultInstance());
+    Watch watch = new Watch(ads, DiscoveryRequest.getDefaultInstance(), r -> { });
 
-    watch.setStop(count::getAndIncrement);
+    watch.setStop(stopCount::getAndIncrement);
 
-    assertThat(((EmitterProcessor<Response>) watch.value()).isTerminated()).isFalse();
+    assertThat(watch.isCancelled()).isFalse();
 
     watch.cancel();
     watch.cancel();
 
-    assertThat(count).hasValue(1);
+    assertThat(stopCount).hasValue(1);
 
-    assertThat(((EmitterProcessor<Response>) watch.value()).isTerminated()).isTrue();
+    assertThat(watch.isCancelled()).isTrue();
+  }
+
+  @Test
+  public void responseHandlerExecutedForResponsesUntilCancelled() {
+    final boolean ads = ThreadLocalRandom.current().nextBoolean();
+
+    Response response1 = Response.create(
+        DiscoveryRequest.newBuilder().build(),
+        ImmutableList.of(),
+        UUID.randomUUID().toString());
+
+    Response response2 = Response.create(
+        DiscoveryRequest.newBuilder().build(),
+        ImmutableList.of(),
+        UUID.randomUUID().toString());
+
+    Response response3 = Response.create(
+        DiscoveryRequest.newBuilder().build(),
+        ImmutableList.of(),
+        UUID.randomUUID().toString());
+
+    List<Response> responses = new LinkedList<>();
+
+    Watch watch = new Watch(ads, DiscoveryRequest.getDefaultInstance(), responses::add);
+
+    watch.respond(response1);
+    watch.respond(response2);
+
+    watch.cancel();
+
+    watch.respond(response3);
+
+    assertThat(responses).containsExactly(response1, response2);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
         <grpc.version>1.12.0</grpc.version>
         <guava.version>20.0</guava.version>
         <junit.version>4.12</junit.version>
-        <reactor.version>3.1.7.RELEASE</reactor.version>
         <rest-assured.version>3.1.0</rest-assured.version>
         <slf4j.version>1.7.25</slf4j.version>
         <testcontainers.version>1.7.3</testcontainers.version>

--- a/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerTest.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerTest.java
@@ -2,7 +2,7 @@ package io.envoyproxy.controlplane.server;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.HashBasedTable;
@@ -32,6 +32,7 @@ import io.envoyproxy.controlplane.cache.Resources;
 import io.envoyproxy.controlplane.cache.Response;
 import io.envoyproxy.controlplane.cache.TestResources;
 import io.envoyproxy.controlplane.cache.Watch;
+import io.envoyproxy.controlplane.cache.WatchCancelledException;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcServerRule;
@@ -752,7 +753,11 @@ public class DiscoveryServerTest {
                 .map(Resources::getResourceName)
                 .collect(Collectors.toSet()));
 
-        watch.respond(response);
+        try {
+          watch.respond(response);
+        } catch (WatchCancelledException e) {
+          fail("watch should not be cancelled", e);
+        }
       } else if (closeWatch) {
         watch.cancel();
       } else {


### PR DESCRIPTION
We weren't really doing much with reactor, so it just ended up adding needless complexity. This change drops usage of reactor and migrates to a more traditional response handler system. The main consequence is that we're now executing the handler in the main server thread, but the handler should not block on any long-running calls.

Signed-off-by: Joey Bratton <jbratton@salesforce.com>