### PR TITLE
server: allow multiple callbacks to be provided

### DIFF
--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
@@ -45,6 +45,11 @@ public class DiscoveryServer {
     this(Collections.singletonList(callbacks), configWatcher);
   }
 
+  /**
+   * Creates the server.
+   * @param callbacks server callbacks
+   * @param configWatcher source of configuration updates
+   */
   public DiscoveryServer(List<DiscoveryServerCallbacks> callbacks, ConfigWatcher configWatcher) {
     Preconditions.checkNotNull(callbacks, "callbacks cannot be null");
     Preconditions.checkNotNull(configWatcher, "configWatcher cannot be null");

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
@@ -2,6 +2,7 @@ package io.envoyproxy.controlplane.server;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+import com.google.common.base.Preconditions;
 import com.google.protobuf.Any;
 import envoy.api.v2.ClusterDiscoveryServiceGrpc.ClusterDiscoveryServiceImplBase;
 import envoy.api.v2.Discovery.DiscoveryRequest;
@@ -45,6 +46,9 @@ public class DiscoveryServer {
   }
 
   public DiscoveryServer(List<DiscoveryServerCallbacks> callbacks, ConfigWatcher configWatcher) {
+    Preconditions.checkNotNull(callbacks, "callbacks cannot be null");
+    Preconditions.checkNotNull(configWatcher, "configWatcher cannot be null");
+
     this.callbacks = callbacks;
     this.configWatcher = configWatcher;
   }


### PR DESCRIPTION
This will make it reasonable to provide open source callbacks that can
be used alongside user defined callbacks.