### PR TITLE
build: update jacoco to support java 11

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -26,6 +26,13 @@
             <artifactId>grpc-stub</artifactId>
             <version>${grpc.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${annotation-api.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Dependency Versions -->
+        <annotation-api.version>1.3.2</annotation-api.version>
         <assertj.version>3.10.0</assertj.version>
         <auto-value.version>1.6</auto-value.version>
         <awaitility.version>3.1.0</awaitility.version>
@@ -34,7 +35,7 @@
         <testcontainers.version>1.7.3</testcontainers.version>
 
         <!-- Maven Plugin Versions -->
-        <jacoco-maven-plugin.version>0.8.0</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>


### PR DESCRIPTION
This allows java-control-plane to build under 11. The annotation-api
dependency was added to work around https://github.com/envoyproxy/data-plane-api/blob/master/XDS_PROTOCOL.m://github.com/grpc/grpc-java/issues/3633