### PR TITLE
Bump protobuf-maven-plugin version and fix Windows build

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -47,12 +47,13 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.1</version>
+                <version>0.6.1</version>
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:3.5.1-1:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.9.0:exe:${os.detected.classifier}</pluginArtifact>
 
+                    <useArgumentFile>true</useArgumentFile>
                     <checkStaleness>true</checkStaleness>
                     <staleMillis>10000</staleMillis>
                 </configuration>


### PR DESCRIPTION
See https://github.com/xolstice/protobuf-maven-plugin/issues/5

- Bump protobuf-maven-plugin to 0.6.1
- Use the `useArgumentFile` as it fixes builds on Windows (due to the Windows command line limit)