### PR TITLE
server: ensure errors not logged when client closes connection (#83)

### DIFF
--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
@@ -221,7 +221,7 @@ public class DiscoveryServer {
 
       @Override
       public void onError(Throwable t) {
-        if (!Status.fromThrowable(t).equals(Status.CANCELLED)) {
+        if (!Status.fromThrowable(t).getCode().equals(Status.CANCELLED.getCode())) {
           LOGGER.error("[{}] stream closed with error", streamId, t);
         }
 

--- a/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerTest.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerTest.java
@@ -39,6 +39,9 @@ import io.envoyproxy.controlplane.cache.WatchCancelledException;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcServerRule;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -746,6 +749,32 @@ public class DiscoveryServerTest {
     assertThat(callbacks.streamOpenCount).hasValue(1);
     assertThat(callbacks.streamRequestCount).hasValue(0);
     assertThat(callbacks.streamResponseCount).hasValue(0);
+  }
+
+  @Test
+  public void callbackOnError_doesNotLogError_whenCancelled() {
+    MockConfigWatcher configWatcher = new MockConfigWatcher(false, createResponses());
+    DiscoveryServer server = new DiscoveryServer(configWatcher);
+
+    grpcServer.getServiceRegistry().addService(server.getAggregatedDiscoveryServiceImpl());
+
+    AggregatedDiscoveryServiceStub stub = AggregatedDiscoveryServiceGrpc.newStub(grpcServer.getChannel());
+
+    MockDiscoveryResponseObserver responseObserver = new MockDiscoveryResponseObserver();
+
+    StreamObserver<DiscoveryRequest> requestObserver = stub.streamAggregatedResources(responseObserver);
+
+    try {
+      ByteArrayOutputStream stdErr = new ByteArrayOutputStream();
+      System.setErr(new PrintStream(stdErr));
+
+      requestObserver.onError(new RuntimeException("send error"));
+
+      assertThat(stdErr.toString()).doesNotContain("ERROR ");
+      assertThat(stdErr.toString()).doesNotContain("io.grpc.StatusRuntimeException: CANCELLED:");
+    } finally {
+      System.setErr(System.err);
+    }
   }
 
   private static Table<String, String, Collection<? extends Message>> createResponses() {


### PR DESCRIPTION
Errors were being logged when client Envoy closes connection while being shut down/restarted.
This change ensures that errors are not logged when the error code is `CANCELLED`.

Fixes https://github.com/envoyproxy/java-control-plane/issues/83