### PR TITLE
cache: respond to watches in parallel v2

### DIFF
--- a/server/src/main/java/io/envoyproxy/controlplane/server/DefaultExecutorGroup.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DefaultExecutorGroup.java
@@ -6,15 +6,13 @@ import java.util.concurrent.Executor;
 
 /**
  * Default implementation of {@link ExecutorGroup} which
- * always returns {@link com.google.common.util.concurrent.MoreExecutors#directExecutor()}.
+ * always returns {@link MoreExecutors#directExecutor}.
  */
 public class DefaultExecutorGroup implements ExecutorGroup {
   /**
-   * Creates a new instance.
+   * Returns the next {@link Executor} to use, which in this case is
+   * always {@link MoreExecutors#directExecutor}.
    */
-  public DefaultExecutorGroup() {
-  }
-
   @Override
   public Executor next() {
     return MoreExecutors.directExecutor();

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DefaultExecutorGroup.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DefaultExecutorGroup.java
@@ -1,0 +1,22 @@
+package io.envoyproxy.controlplane.server;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Default implementation of {@link ExecutorGroup} which
+ * always returns {@link com.google.common.util.concurrent.MoreExecutors#directExecutor()}.
+ */
+public class DefaultExecutorGroup implements ExecutorGroup {
+  /**
+   * Creates a new instance.
+   */
+  public DefaultExecutorGroup() {
+  }
+
+  @Override
+  public Executor next() {
+    return MoreExecutors.directExecutor();
+  }
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
@@ -65,7 +65,8 @@ public class DiscoveryServer {
    * @param configWatcher source of configuration updates
    * @param executorGroup executor group to use for responding stream requests
    */
-  public DiscoveryServer(List<DiscoveryServerCallbacks> callbacks, ConfigWatcher configWatcher,
+  public DiscoveryServer(List<DiscoveryServerCallbacks> callbacks,
+                         ConfigWatcher configWatcher,
                          ExecutorGroup executorGroup) {
     Preconditions.checkNotNull(callbacks, "callbacks cannot be null");
     Preconditions.checkNotNull(configWatcher, "configWatcher cannot be null");
@@ -193,8 +194,11 @@ public class DiscoveryServer {
 
     private AtomicLong streamNonce;
 
-    public DiscoveryRequestStreamObserver(String defaultTypeUrl, StreamObserver<DiscoveryResponse> responseObserver,
-                                          long streamId, boolean ads, Executor executor) {
+    public DiscoveryRequestStreamObserver(String defaultTypeUrl,
+                                          StreamObserver<DiscoveryResponse> responseObserver,
+                                          long streamId,
+                                          boolean ads,
+                                          Executor executor) {
       this.defaultTypeUrl = defaultTypeUrl;
       this.responseObserver = responseObserver;
       this.streamId = streamId;

--- a/server/src/main/java/io/envoyproxy/controlplane/server/ExecutorGroup.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/ExecutorGroup.java
@@ -1,0 +1,15 @@
+package io.envoyproxy.controlplane.server;
+
+import java.util.concurrent.Executor;
+
+/**
+ * The {@link ExecutorGroup} is responsible for providing the {@link Executor}'s to use
+ * via its {@link #next()} method.
+ */
+public interface ExecutorGroup {
+  /**
+   * Return the next {@link Executor} to use.
+   *
+   */
+  Executor next();
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/ExecutorGroup.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/ExecutorGroup.java
@@ -8,8 +8,7 @@ import java.util.concurrent.Executor;
  */
 public interface ExecutorGroup {
   /**
-   * Return the next {@link Executor} to use.
-   *
+   * Returns the next {@link Executor} to use.
    */
   Executor next();
 }


### PR DESCRIPTION
Supersedes #75 

Added concept of `ExecutorGroup` mostly based on netty's `EventExecutorGroup` for distributing `Executor`s to streams in a round robin fashion.