### PR TITLE
cache: Add separate cluster versioning

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -100,7 +100,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
       status.setLastWatchRequestTime(System.currentTimeMillis());
 
       Snapshot snapshot = snapshots.get(group);
-      String version = snapshot == null ? "" : snapshot.version(request.getTypeUrl());
+      String version = snapshot == null ? "" : snapshot.version(request.getTypeUrl(), request.getResourceNamesList());
 
       Watch watch = new Watch(ads, request, responseConsumer);
 
@@ -198,7 +198,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
       }
 
       status.watchesRemoveIf((id, watch) -> {
-        String version = snapshot.version(watch.request().getTypeUrl());
+        String version = snapshot.version(watch.request().getTypeUrl(), watch.request().getResourceNamesList());
 
         if (!watch.request().getVersionInfo().equals(version)) {
           LOGGER.info("responding to open watch {}[{}] with new version {}",
@@ -258,7 +258,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
             "not responding in ADS mode for {} from node {} at version {} for request [{}] since [{}] not in snapshot",
             watch.request().getTypeUrl(),
             group,
-            snapshot.version(watch.request().getTypeUrl()),
+            snapshot.version(watch.request().getTypeUrl(), watch.request().getResourceNamesList()),
             String.join(", ", watch.request().getResourceNamesList()),
             String.join(", ", missingNames));
 
@@ -266,7 +266,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
       }
     }
 
-    String version = snapshot.version(watch.request().getTypeUrl());
+    String version = snapshot.version(watch.request().getTypeUrl(), watch.request().getResourceNamesList());
 
     LOGGER.info("responding for {} from node {} at version {} with version {}",
         watch.request().getTypeUrl(),

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/Snapshot.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/Snapshot.java
@@ -16,6 +16,7 @@ import io.envoyproxy.envoy.api.v2.Lds.Listener;
 import io.envoyproxy.envoy.api.v2.Rds.RouteConfiguration;
 import io.envoyproxy.envoy.api.v2.auth.Cert.Secret;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -79,6 +80,38 @@ public abstract class Snapshot {
     return new AutoValue_Snapshot(
         SnapshotResources.create(clusters, clustersVersion),
         SnapshotResources.create(endpoints, endpointsVersion),
+        SnapshotResources.create(listeners, listenersVersion),
+        SnapshotResources.create(routes, routesVersion),
+        SnapshotResources.create(secrets, secretsVersion));
+  }
+
+  /**
+   * Returns a new {@link Snapshot} instance that has separate versions for each resource type.
+   *
+   * @param clusters the cluster resources in this snapshot
+   * @param clustersVersion the version of the cluster resources
+   * @param endpoints the endpoint resources in this snapshot
+   * @param endpointVersions versions for cluster names
+   * @param listeners the listener resources in this snapshot
+   * @param listenersVersion the version of the listener resources
+   * @param routes the route resources in this snapshot
+   * @param routesVersion the version of the route resources
+   */
+  public static Snapshot create(
+      Iterable<Cluster> clusters,
+      String clustersVersion,
+      Iterable<ClusterLoadAssignment> endpoints,
+      Map<String, String> endpointVersions,
+      Iterable<Listener> listeners,
+      String listenersVersion,
+      Iterable<RouteConfiguration> routes,
+      String routesVersion,
+      Iterable<Secret> secrets,
+      String secretsVersion) {
+
+    return new AutoValue_Snapshot(
+        SnapshotResources.create(clusters, clustersVersion),
+        SnapshotResources.create(endpoints, clustersVersion, endpointVersions),
         SnapshotResources.create(listeners, listenersVersion),
         SnapshotResources.create(routes, routesVersion),
         SnapshotResources.create(secrets, secretsVersion));
@@ -170,21 +203,31 @@ public abstract class Snapshot {
    * @param typeUrl the URL for the requested resource type
    */
   public String version(String typeUrl) {
+    return version(typeUrl, Collections.emptyList());
+  }
+
+  /**
+   * Returns the version in this snapshot for the given resource type.
+   *
+   * @param typeUrl the URL for the requested resource type
+   * @param resourceNames list of resource names
+   */
+  public String version(String typeUrl, List<String> resourceNames) {
     if (Strings.isNullOrEmpty(typeUrl)) {
       return "";
     }
 
     switch (typeUrl) {
       case CLUSTER_TYPE_URL:
-        return clusters().version();
+        return clusters().version(resourceNames);
       case ENDPOINT_TYPE_URL:
-        return endpoints().version();
+        return endpoints().version(resourceNames);
       case LISTENER_TYPE_URL:
-        return listeners().version();
+        return listeners().version(resourceNames);
       case ROUTE_TYPE_URL:
-        return routes().version();
+        return routes().version(resourceNames);
       case SECRET_TYPE_URL:
-        return secrets().version();
+        return secrets().version(resourceNames);
       default:
         return "";
     }

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SnapshotResources.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SnapshotResources.java
@@ -3,6 +3,9 @@ package io.envoyproxy.controlplane.cache;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Message;
+
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collector;
 import java.util.stream.StreamSupport;
@@ -19,14 +22,38 @@ public abstract class SnapshotResources<T extends Message> {
    */
   public static <T extends Message> SnapshotResources<T> create(Iterable<T> resources, String version) {
     return new AutoValue_SnapshotResources<>(
-        StreamSupport.stream(resources.spliterator(), false)
-            .collect(
-                Collector.of(
-                    ImmutableMap.Builder<String, T>::new,
-                    (b, e) -> b.put(Resources.getResourceName(e), e),
-                    (b1, b2) -> b1.putAll(b2.build()),
-                    ImmutableMap.Builder::build)),
-        version);
+        resourcesMap(resources),
+        version,
+        new HashMap<>());
+  }
+
+  /**
+   * Returns a new {@link SnapshotResources} instance with versions by resource name.
+   *
+   * @param resources the resources in this collection
+   * @param version the aggregated version for the resources in this collection
+   * @param versionsByResourceName map of versions by resource name
+   * @param <T> the type of resources in this collection
+   */
+  public static <T extends Message> SnapshotResources<T> create(
+      Iterable<T> resources,
+      String version,
+      Map<String, String> versionsByResourceName
+  ) {
+    return new AutoValue_SnapshotResources<>(
+        resourcesMap(resources),
+        version,
+        versionsByResourceName);
+  }
+
+  private static <T extends Message> ImmutableMap<String, T> resourcesMap(Iterable<T> resources) {
+    return StreamSupport.stream(resources.spliterator(), false)
+        .collect(
+            Collector.of(
+                ImmutableMap.Builder<String, T>::new,
+                (b, e) -> b.put(Resources.getResourceName(e), e),
+                (b1, b2) -> b1.putAll(b2.build()),
+                ImmutableMap.Builder::build));
   }
 
   /**
@@ -38,4 +65,20 @@ public abstract class SnapshotResources<T extends Message> {
    * Returns the version associated with this resources in this collection.
    */
   public abstract String version();
+
+  /**
+   * Returns the version associated with this resources in this collection, where the key is the name of the resource.
+   */
+  public String version(List<String> resourceNames) {
+    if (resourceNames.size() != 1 || !versionsByResourceName().containsKey(resourceNames.get(0))) {
+      return version();
+    }
+    return versionsByResourceName().get(resourceNames.get(0));
+  }
+
+  /**
+   * Returns the versions associated with this resources in this collection.
+   */
+  public abstract Map<String, String> versionsByResourceName();
+
 }

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/SnapshotResourcesTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/SnapshotResourcesTest.java
@@ -3,7 +3,10 @@ package io.envoyproxy.controlplane.cache;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.envoyproxy.envoy.api.v2.Cds.Cluster;
+
+import java.util.Map;
 import java.util.UUID;
 import org.junit.Test;
 
@@ -27,5 +30,32 @@ public class SnapshotResourcesTest {
         .hasSize(2);
 
     assertThat(snapshot.version()).isEqualTo(version);
+  }
+
+  @Test
+  public void populatesVersionWithSeparateVersionPerCluster() {
+    final String aggregateVersion = UUID.randomUUID().toString();
+
+    final Map<String, String> versions = ImmutableMap.of(
+        CLUSTER0_NAME, UUID.randomUUID().toString(),
+        CLUSTER1_NAME, UUID.randomUUID().toString()
+    );
+
+    SnapshotResources<Cluster> snapshot = SnapshotResources.create(
+        ImmutableList.of(CLUSTER0, CLUSTER1), aggregateVersion, versions
+    );
+
+    // when no resources name provided, the aggregated version should be returned
+    assertThat(snapshot.version()).isEqualTo(aggregateVersion);
+
+    // when one resource name provided, the cluster version should be returned
+    assertThat(snapshot.version(ImmutableList.of(CLUSTER0_NAME))).isEqualTo(versions.get(CLUSTER0_NAME));
+    assertThat(snapshot.version(ImmutableList.of(CLUSTER1_NAME))).isEqualTo(versions.get(CLUSTER1_NAME));
+
+    // when unknown resource name provided, the aggregated version should be returned
+    assertThat(snapshot.version(ImmutableList.of("unknown_cluster_name"))).isEqualTo(aggregateVersion);
+
+    // when multiple resource names provided, the aggregated version should be returned
+    assertThat(snapshot.version(ImmutableList.of(CLUSTER1_NAME, CLUSTER1_NAME))).isEqualTo(aggregateVersion);
   }
 }

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/SnapshotTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/SnapshotTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Message;
 import io.envoyproxy.envoy.api.v2.Cds.Cluster;
 import io.envoyproxy.envoy.api.v2.Eds.ClusterLoadAssignment;
@@ -105,6 +106,49 @@ public class SnapshotTest {
 
     assertThat(snapshot.clusters().version()).isEqualTo(clustersVersion);
     assertThat(snapshot.endpoints().version()).isEqualTo(endpointsVersion);
+    assertThat(snapshot.listeners().version()).isEqualTo(listenersVersion);
+    assertThat(snapshot.routes().version()).isEqualTo(routesVersion);
+  }
+
+  @Test
+  public void createSeparateVersionsForEachCluster() {
+    final String clustersVersion = UUID.randomUUID().toString();
+    final String listenersVersion = UUID.randomUUID().toString();
+    final String routesVersion = UUID.randomUUID().toString();
+    final String secretsVersion = UUID.randomUUID().toString();
+
+    final Map<String, String> endpointVersions = ImmutableMap.of(
+        CLUSTER_NAME, UUID.randomUUID().toString()
+    );
+
+    Snapshot snapshot = Snapshot.create(
+        ImmutableList.of(CLUSTER), clustersVersion,
+        ImmutableList.of(ENDPOINT), endpointVersions,
+        ImmutableList.of(LISTENER), listenersVersion,
+        ImmutableList.of(ROUTE), routesVersion,
+        ImmutableList.of(SECRET), secretsVersion
+    );
+
+    assertThat(snapshot.clusters().resources())
+        .containsEntry(CLUSTER_NAME, CLUSTER)
+        .hasSize(1);
+
+    assertThat(snapshot.endpoints().resources())
+        .containsEntry(CLUSTER_NAME, ENDPOINT)
+        .hasSize(1);
+
+    assertThat(snapshot.listeners().resources())
+        .containsEntry(LISTENER_NAME, LISTENER)
+        .hasSize(1);
+
+    assertThat(snapshot.routes().resources())
+        .containsEntry(ROUTE_NAME, ROUTE)
+        .hasSize(1);
+
+    assertThat(snapshot.clusters().version()).isEqualTo(clustersVersion);
+    assertThat(snapshot.endpoints().version()).isEqualTo(clustersVersion);
+    assertThat(snapshot.endpoints().version(ImmutableList.of(CLUSTER_NAME)))
+        .isEqualTo(endpointVersions.get(CLUSTER_NAME));
     assertThat(snapshot.listeners().version()).isEqualTo(listenersVersion);
     assertThat(snapshot.routes().version()).isEqualTo(routesVersion);
   }


### PR DESCRIPTION
Solves #89 .
It adds option to version each cluster individually. I tried to make an API backward compatible.

Currently, only separate version for single resource name is supported.

Let's say we've got
Cluster (version `c1`) of `A` `B`
and individual versions:
`A`: `a1`
`B`: `b1`

When we ask about version for cluster `A`, we return `a1`, for `B` is `b1`, but when we ask about `A` _and_ `B` in one request, we return `c1`.
I observed that with java-control-plane, Envoy only asks for one resource in EDS, but it is defined in xDS spec that it can be a list.

To return individual combined version for `A` and `B` we would have to combine it somehow. There is no easy way to do it by default. We could hash the list, but we could get hash collisions. That's why in this case we just return version of the cluster.

I could code the strategy here if you think it's better. In this way, the client of `Snapshot` class would choose what to do in case of the request with multiple resource names. 