### PR TITLE
cache: respond to watches in a specific order

### DIFF
--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
@@ -12,6 +12,7 @@ import io.envoyproxy.envoy.api.v2.RouteConfiguration;
 import io.envoyproxy.envoy.api.v2.auth.Secret;
 import io.envoyproxy.envoy.api.v2.core.Node;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.UUID;
@@ -164,25 +165,35 @@ public class SimpleCacheTest {
 
     cache.setSnapshot(SingleNodeGroup.GROUP, SNAPSHOT1);
 
-    Map<String, WatchAndTracker> watches = Resources.TYPE_URLS.stream()
-        .collect(Collectors.toMap(
-            typeUrl -> typeUrl,
-            typeUrl -> {
-              ResponseTracker responseTracker = new ResponseTracker();
+    ResponseOrderTracker responseOrderTracker = new ResponseOrderTracker();
 
-              Watch watch = cache.createWatch(
-                  ADS,
-                  DiscoveryRequest.newBuilder()
-                      .setNode(Node.getDefaultInstance())
-                      .setTypeUrl(typeUrl)
-                      .setVersionInfo(SNAPSHOT1.version(typeUrl))
-                      .addAllResourceNames(SNAPSHOT1.resources(typeUrl).keySet())
-                      .build(),
-                  SNAPSHOT2.resources(typeUrl).keySet(),
-                  responseTracker);
+    HashMap<String, WatchAndTracker> watches = new HashMap<>();
 
-              return new WatchAndTracker(watch, responseTracker);
-            }));
+    for (int i = 0; i < 2; ++i) {
+      watches.putAll(Resources.TYPE_URLS.stream()
+          .collect(Collectors.toMap(
+              typeUrl -> typeUrl,
+              typeUrl -> {
+                ResponseTracker responseTracker = new ResponseTracker();
+
+                Watch watch = cache.createWatch(
+                    ADS,
+                    DiscoveryRequest.newBuilder()
+                        .setNode(Node.getDefaultInstance())
+                        .setTypeUrl(typeUrl)
+                        .setVersionInfo(SNAPSHOT1.version(typeUrl))
+                        .addAllResourceNames(SNAPSHOT1.resources(typeUrl).keySet())
+                        .build(),
+                    SNAPSHOT2.resources(typeUrl).keySet(),
+                    r -> {
+                      responseTracker.accept(r);
+                      responseOrderTracker.accept(r);
+                    });
+
+                return new WatchAndTracker(watch, responseTracker);
+              }))
+      );
+    }
 
     // The request version matches the current snapshot version, so the watches shouldn't receive any responses.
     for (String typeUrl : Resources.TYPE_URLS) {
@@ -194,6 +205,12 @@ public class SimpleCacheTest {
     for (String typeUrl : Resources.TYPE_URLS) {
       assertThatWatchReceivesSnapshot(watches.get(typeUrl), SNAPSHOT2);
     }
+
+    // Verify that CDS and LDS always get triggered before EDS and RDS respectively.
+    assertThat(responseOrderTracker.responseTypes).containsExactly(Resources.CLUSTER_TYPE_URL,
+        Resources.CLUSTER_TYPE_URL, Resources.ENDPOINT_TYPE_URL, Resources.ENDPOINT_TYPE_URL,
+        Resources.LISTENER_TYPE_URL, Resources.LISTENER_TYPE_URL, Resources.ROUTE_TYPE_URL,
+        Resources.ROUTE_TYPE_URL, Resources.SECRET_TYPE_URL, Resources.SECRET_TYPE_URL);
   }
 
   @Test
@@ -435,6 +452,15 @@ public class SimpleCacheTest {
     @Override
     public void accept(Response response) {
       responses.add(response);
+    }
+  }
+
+  private static class ResponseOrderTracker implements Consumer<Response> {
+
+    private final LinkedList<String> responseTypes = new LinkedList<>();
+
+    @Override public void accept(Response response) {
+      responseTypes.add(response.request().getTypeUrl());
     }
   }
 


### PR DESCRIPTION
Ensures that watches are triggered in such a way that EDS and RDS are
triggered *after* CDS and LDS. This follows the reccomendation in the
XDS spec
(see https://github.com/envoyproxy/data-plane-api/blob/master/XDS_PROTOCOL.md#eventual-consistency-considerations).

Signed-off-by: Snow Pettersen <snowp@squareup.com>