### PR TITLE
server: Refactor stream observer

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/Watch.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/Watch.java
@@ -1,7 +1,6 @@
 package io.envoyproxy.controlplane.cache;
 
 import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Consumer;
 

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/Watch.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/Watch.java
@@ -1,7 +1,8 @@
 package io.envoyproxy.controlplane.cache;
 
 import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
-import java.util.concurrent.atomic.AtomicBoolean;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Consumer;
 
 /**
@@ -9,19 +10,19 @@ import java.util.function.Consumer;
  * the xDS server.
  */
 public class Watch {
-
+  private static final AtomicIntegerFieldUpdater<Watch> isCancelledUpdater =
+      AtomicIntegerFieldUpdater.newUpdater(Watch.class, "isCancelled");
   private final boolean ads;
-  private final AtomicBoolean isCancelled = new AtomicBoolean();
   private final DiscoveryRequest request;
   private final Consumer<Response> responseConsumer;
-
+  private volatile int isCancelled = 0;
   private Runnable stop;
 
   /**
    * Construct a watch.
    *
-   * @param ads is this watch for an ADS request?
-   * @param request the original request for the watch
+   * @param ads              is this watch for an ADS request?
+   * @param request          the original request for the watch
    * @param responseConsumer handler for outgoing response messages
    */
   public Watch(boolean ads, DiscoveryRequest request, Consumer<Response> responseConsumer) {
@@ -42,7 +43,7 @@ public class Watch {
    * may be called multiple times, with each subsequent call being a no-op.
    */
   public void cancel() {
-    if (isCancelled.compareAndSet(false, true)) {
+    if (isCancelledUpdater.compareAndSet(this, 0, 1)) {
       if (stop != null) {
         stop.run();
       }
@@ -53,7 +54,7 @@ public class Watch {
    * Returns boolean indicating whether or not the watch has been cancelled.
    */
   public boolean isCancelled() {
-    return isCancelled.get();
+    return isCancelledUpdater.get(this) == 1;
   }
 
   /**

--- a/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
@@ -15,6 +15,10 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
+/**
+ * {@code AdsDiscoveryRequestStreamObserver} is an implementation of {@link DiscoveryRequestStreamObserver} tailored for
+ * ADS streams, which handle multiple watches for all TYPE_URLS.
+ */
 public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObserver {
   private final ConcurrentMap<String, Watch> watches;
   private final ConcurrentMap<String, DiscoveryResponse> latestResponse;

--- a/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
@@ -19,12 +19,11 @@ public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
   private final ConcurrentMap<String, DiscoveryResponse> latestResponse;
   private final ConcurrentMap<String, Set<String>> ackedResources;
 
-  AdsDiscoveryRequestStreamObserver(String defaultTypeUrl,
-                                    StreamObserver<DiscoveryResponse> responseObserver,
+  AdsDiscoveryRequestStreamObserver(StreamObserver<DiscoveryResponse> responseObserver,
                                     long streamId,
                                     Executor executor,
                                     DiscoveryServer discoveryServer) {
-    super(defaultTypeUrl, responseObserver, streamId, executor, discoveryServer);
+    super(ANY_TYPE_URL, responseObserver, streamId, executor, discoveryServer);
     this.watches = new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
     this.latestResponse = new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
     this.ackedResources = new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
@@ -34,17 +33,13 @@ public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
   public void onNext(DiscoveryRequest request) {
     String requestTypeUrl = request.getTypeUrl();
 
-    if (defaultTypeUrl.equals(ANY_TYPE_URL)) {
-      if (requestTypeUrl.isEmpty()) {
-        responseObserver.onError(
-            Status.UNKNOWN
-                .withDescription(String.format("[%d] type URL is required for ADS", streamId))
-                .asRuntimeException());
+    if (requestTypeUrl.isEmpty()) {
+      responseObserver.onError(
+          Status.UNKNOWN
+              .withDescription(String.format("[%d] type URL is required for ADS", streamId))
+              .asRuntimeException());
 
-        return;
-      }
-    } else if (requestTypeUrl.isEmpty()) {
-      requestTypeUrl = defaultTypeUrl;
+      return;
     }
 
     processRequest(requestTypeUrl, request);

--- a/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
@@ -1,0 +1,93 @@
+package io.envoyproxy.controlplane.server;
+
+import static io.envoyproxy.controlplane.server.DiscoveryServer.ANY_TYPE_URL;
+
+import io.envoyproxy.controlplane.cache.Resources;
+import io.envoyproxy.controlplane.cache.Watch;
+import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
+import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObserver {
+  private final ConcurrentMap<String, Watch> watches;
+  private final ConcurrentMap<String, DiscoveryResponse> latestResponse;
+  private final ConcurrentMap<String, Set<String>> ackedResources;
+
+  AdsDiscoveryRequestStreamObserver(String defaultTypeUrl,
+                                    StreamObserver<DiscoveryResponse> responseObserver,
+                                    long streamId,
+                                    Executor executor,
+                                    DiscoveryServer discoveryServer) {
+    super(defaultTypeUrl, responseObserver, streamId, executor, discoveryServer);
+    this.watches = new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
+    this.latestResponse = new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
+    this.ackedResources = new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
+  }
+
+  @Override
+  public void onNext(DiscoveryRequest request) {
+    String requestTypeUrl = request.getTypeUrl();
+
+    if (defaultTypeUrl.equals(ANY_TYPE_URL)) {
+      if (requestTypeUrl.isEmpty()) {
+        responseObserver.onError(
+            Status.UNKNOWN
+                .withDescription(String.format("[%d] type URL is required for ADS", streamId))
+                .asRuntimeException());
+
+        return;
+      }
+    } else if (requestTypeUrl.isEmpty()) {
+      requestTypeUrl = defaultTypeUrl;
+    }
+
+    processRequest(requestTypeUrl, request);
+  }
+
+  @Override
+  void cancel() {
+    watches.values().forEach(Watch::cancel);
+  }
+
+  @Override
+  boolean ads() {
+    return true;
+  }
+
+  @Override
+  DiscoveryResponse latestResponse(String typeUrl) {
+    return latestResponse.get(typeUrl);
+  }
+
+  @Override
+  void setLatestResponse(String typeUrl, DiscoveryResponse response) {
+    latestResponse.put(typeUrl, response);
+  }
+
+  @Override
+  Set<String> ackedResources(String typeUrl) {
+    return ackedResources.get(typeUrl);
+  }
+
+  @Override
+  void setAckedResources(String typeUrl, Set<String> resources) {
+    ackedResources.put(typeUrl, resources);
+  }
+
+  @Override
+  void computeWatch(String typeUrl, Supplier<Watch> watchCreator) {
+    watches.compute(typeUrl, (s, watch) -> {
+      if (watch != null) {
+        watch.cancel();
+      }
+
+      return watchCreator.get();
+    });
+  }
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
@@ -8,6 +8,7 @@ import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -67,7 +68,7 @@ public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
 
   @Override
   Set<String> ackedResources(String typeUrl) {
-    return ackedResources.get(typeUrl);
+    return ackedResources.getOrDefault(typeUrl, Collections.emptySet());
   }
 
   @Override

--- a/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
@@ -36,9 +36,7 @@ public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
 
   @Override
   public void onNext(DiscoveryRequest request) {
-    String requestTypeUrl = request.getTypeUrl();
-
-    if (requestTypeUrl.isEmpty()) {
+    if (request.getTypeUrl().isEmpty()) {
       closeWithError(
           Status.UNKNOWN
               .withDescription(String.format("[%d] type URL is required for ADS", streamId))
@@ -47,7 +45,7 @@ public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
       return;
     }
 
-    processRequest(requestTypeUrl, request);
+    super.onNext(request);
   }
 
   @Override

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -29,8 +29,8 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
       AtomicLongFieldUpdater.newUpdater(DiscoveryRequestStreamObserver.class, "streamNonce");
   private static final Logger LOGGER = LoggerFactory.getLogger(DiscoveryServer.class);
 
-  final String defaultTypeUrl;
   final long streamId;
+  private final String defaultTypeUrl;
   private final StreamObserver<DiscoveryResponse> responseObserver;
   private final Executor executor;
   private final DiscoveryServer discoverySever;

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -1,5 +1,7 @@
 package io.envoyproxy.controlplane.server;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import com.google.protobuf.Any;
 import io.envoyproxy.controlplane.cache.Resources;
 import io.envoyproxy.controlplane.cache.Response;
@@ -10,9 +12,6 @@ import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -20,8 +19,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class DiscoveryRequestStreamObserver implements StreamObserver<DiscoveryRequest> {
   private static final AtomicLongFieldUpdater<DiscoveryRequestStreamObserver> streamNonceUpdater =
@@ -38,7 +37,11 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
   private volatile long streamNonce;
   private volatile int isClosing;
 
-  DiscoveryRequestStreamObserver(String defaultTypeUrl, StreamObserver<DiscoveryResponse> responseObserver, long streamId, Executor executor, DiscoveryServer discoveryServer) {
+  DiscoveryRequestStreamObserver(String defaultTypeUrl,
+                                 StreamObserver<DiscoveryResponse> responseObserver,
+                                 long streamId,
+                                 Executor executor,
+                                 DiscoveryServer discoveryServer) {
     this.defaultTypeUrl = defaultTypeUrl;
     this.responseObserver = responseObserver;
     this.streamId = streamId;

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -1,0 +1,169 @@
+package io.envoyproxy.controlplane.server;
+
+import com.google.protobuf.Any;
+import io.envoyproxy.controlplane.cache.Resources;
+import io.envoyproxy.controlplane.cache.Response;
+import io.envoyproxy.controlplane.cache.Watch;
+import io.envoyproxy.controlplane.server.exception.RequestException;
+import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
+import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public abstract class DiscoveryRequestStreamObserver implements StreamObserver<DiscoveryRequest> {
+  private static final AtomicLongFieldUpdater<DiscoveryRequestStreamObserver> streamNonceUpdater =
+      AtomicLongFieldUpdater.newUpdater(DiscoveryRequestStreamObserver.class, "streamNonce");
+  private static final AtomicIntegerFieldUpdater<DiscoveryRequestStreamObserver> isClosingUpdater =
+      AtomicIntegerFieldUpdater.newUpdater(DiscoveryRequestStreamObserver.class, "isClosing");
+  private static final Logger LOGGER = LoggerFactory.getLogger(DiscoveryServer.class);
+
+  final String defaultTypeUrl;
+  final long streamId;
+  final StreamObserver<DiscoveryResponse> responseObserver;
+  private final Executor executor;
+  private final DiscoveryServer discoverySever;
+  private volatile long streamNonce;
+  private volatile int isClosing;
+
+  DiscoveryRequestStreamObserver(String defaultTypeUrl, StreamObserver<DiscoveryResponse> responseObserver, long streamId, Executor executor, DiscoveryServer discoveryServer) {
+    this.defaultTypeUrl = defaultTypeUrl;
+    this.responseObserver = responseObserver;
+    this.streamId = streamId;
+    this.executor = executor;
+    this.streamNonce = 0;
+    this.discoverySever = discoveryServer;
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    if (!Status.fromThrowable(t).getCode().equals(Status.CANCELLED.getCode())) {
+      LOGGER.error("[{}] stream closed with error", streamId, t);
+    }
+
+    try {
+      discoverySever.callbacks.forEach(cb -> cb.onStreamCloseWithError(streamId, defaultTypeUrl, t));
+      responseObserver.onError(Status.fromThrowable(t).asException());
+    } finally {
+      cancel();
+    }
+  }
+
+  @Override
+  public void onCompleted() {
+    LOGGER.debug("[{}] stream closed", streamId);
+
+    try {
+      discoverySever.callbacks.forEach(cb -> cb.onStreamClose(streamId, defaultTypeUrl));
+      responseObserver.onCompleted();
+    } finally {
+      cancel();
+    }
+  }
+
+  void onCancelled() {
+    LOGGER.info("[{}] stream cancelled", streamId);
+    cancel();
+  }
+
+  void processRequest(String requestTypeUrl, DiscoveryRequest request) {
+    String nonce = request.getResponseNonce();
+
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("[{}] request {}[{}] with nonce {} from version {}",
+          streamId,
+          requestTypeUrl,
+          String.join(", ", request.getResourceNamesList()),
+          nonce,
+          request.getVersionInfo());
+    }
+
+    try {
+      discoverySever.callbacks.forEach(cb -> cb.onStreamRequest(streamId, request));
+    } catch (RequestException e) {
+      closeWithError(e);
+      return;
+    }
+
+    DiscoveryResponse latestResponse = latestResponse(requestTypeUrl);
+    String resourceNonce = latestResponse == null ? null : latestResponse.getNonce();
+
+    if (isNullOrEmpty(resourceNonce)
+        || resourceNonce.equals(nonce)) {
+      if (!request.hasErrorDetail() && latestResponse != null) {
+        Set<String> ackedResourcesForType = latestResponse.getResourcesList()
+            .stream()
+            .map(Resources::getResourceName)
+            .collect(Collectors.toSet());
+        setAckedResources(requestTypeUrl, ackedResourcesForType);
+      }
+
+      computeWatch(requestTypeUrl, () -> discoverySever.configWatcher.createWatch(
+          ads(),
+          request,
+          ackedResources(requestTypeUrl),
+          r -> executor.execute(() -> send(r, requestTypeUrl))));
+    }
+  }
+
+  private void closeWithError(Throwable exception) {
+    if (isClosingUpdater.compareAndSet(this, 0, 1)) {
+      responseObserver.onError(exception);
+    }
+    cancel();
+  }
+
+  private void send(Response response, String typeUrl) {
+    String nonce = Long.toString(streamNonceUpdater.getAndIncrement(this));
+
+    Collection<Any> resources = discoverySever.protoResourcesSerializer.serialize(response.resources());
+    DiscoveryResponse discoveryResponse = DiscoveryResponse.newBuilder()
+        .setVersionInfo(response.version())
+        .addAllResources(resources)
+        .setTypeUrl(typeUrl)
+        .setNonce(nonce)
+        .build();
+
+    LOGGER.debug("[{}] response {} with nonce {} version {}", streamId, typeUrl, nonce, response.version());
+
+    discoverySever.callbacks.forEach(cb -> cb.onStreamResponse(streamId, response.request(), discoveryResponse));
+
+    // Store the latest response *before* we send the response. This ensures that by the time the request
+    // is processed the map is guaranteed to be updated. Doing it afterwards leads to a race conditions
+    // which may see the incoming request arrive before the map is updated, failing the nonce check erroneously.
+    setLatestResponse(typeUrl, discoveryResponse);
+    try {
+      responseObserver.onNext(discoveryResponse);
+    } catch (StatusRuntimeException e) {
+      if (!Status.CANCELLED.getCode().equals(e.getStatus().getCode())) {
+        throw e;
+      }
+    }
+  }
+
+  abstract void cancel();
+
+  abstract boolean ads();
+
+  abstract DiscoveryResponse latestResponse(String typeUrl);
+
+  abstract void setLatestResponse(String typeUrl, DiscoveryResponse response);
+
+  abstract Set<String> ackedResources(String typeUrl);
+
+  abstract void setAckedResources(String typeUrl, Set<String> resources);
+
+  abstract void computeWatch(String typeUrl, Supplier<Watch> watchCreator);
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -22,6 +22,9 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * {@code DiscoveryRequestStreamObserver} is provides the base implementation for XDS stream handling.
+ */
 public abstract class DiscoveryRequestStreamObserver implements StreamObserver<DiscoveryRequest> {
   private static final AtomicLongFieldUpdater<DiscoveryRequestStreamObserver> streamNonceUpdater =
       AtomicLongFieldUpdater.newUpdater(DiscoveryRequestStreamObserver.class, "streamNonce");

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@code DiscoveryRequestStreamObserver} is provides the base implementation for XDS stream handling.
+ * {@code DiscoveryRequestStreamObserver} provides the base implementation for XDS stream handling.
  */
 public abstract class DiscoveryRequestStreamObserver implements StreamObserver<DiscoveryRequest> {
   private static final AtomicLongFieldUpdater<DiscoveryRequestStreamObserver> streamNonceUpdater =

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -28,8 +28,6 @@ import org.slf4j.LoggerFactory;
 public abstract class DiscoveryRequestStreamObserver implements StreamObserver<DiscoveryRequest> {
   private static final AtomicLongFieldUpdater<DiscoveryRequestStreamObserver> streamNonceUpdater =
       AtomicLongFieldUpdater.newUpdater(DiscoveryRequestStreamObserver.class, "streamNonce");
-  private static final AtomicIntegerFieldUpdater<DiscoveryRequestStreamObserver> isClosingUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(DiscoveryRequestStreamObserver.class, "isClosing");
   private static final Logger LOGGER = LoggerFactory.getLogger(DiscoveryServer.class);
 
   final String defaultTypeUrl;

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -15,7 +15,6 @@ import io.grpc.stub.StreamObserver;
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -74,8 +74,7 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
     DiscoveryResponse latestResponse = latestResponse(requestTypeUrl);
     String resourceNonce = latestResponse == null ? null : latestResponse.getNonce();
 
-    if (isNullOrEmpty(resourceNonce)
-        || resourceNonce.equals(nonce)) {
+    if (isNullOrEmpty(resourceNonce) || resourceNonce.equals(nonce)) {
       if (!request.hasErrorDetail() && latestResponse != null) {
         Set<String> ackedResourcesForType = latestResponse.getResourcesList()
             .stream()

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
@@ -169,9 +169,20 @@ public class DiscoveryServer {
 
     final DiscoveryRequestStreamObserver requestStreamObserver;
     if (ads) {
-      requestStreamObserver = new AdsDiscoveryRequestStreamObserver(defaultTypeUrl, responseObserver, streamId, executor, this);
+      requestStreamObserver = new AdsDiscoveryRequestStreamObserver(
+          responseObserver,
+          streamId,
+          executor,
+          this
+      );
     } else {
-      requestStreamObserver = new XdsDiscoveryRequestStreamObserver(defaultTypeUrl, responseObserver, streamId, executor, this);
+      requestStreamObserver = new XdsDiscoveryRequestStreamObserver(
+          defaultTypeUrl,
+          responseObserver,
+          streamId,
+          executor,
+          this
+      );
     }
 
     if (responseObserver instanceof ServerCallStreamObserver) {

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
@@ -1,14 +1,8 @@
 package io.envoyproxy.controlplane.server;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-
 import com.google.common.base.Preconditions;
-import com.google.protobuf.Any;
 import io.envoyproxy.controlplane.cache.ConfigWatcher;
 import io.envoyproxy.controlplane.cache.Resources;
-import io.envoyproxy.controlplane.cache.Response;
-import io.envoyproxy.controlplane.cache.Watch;
-import io.envoyproxy.controlplane.server.exception.RequestException;
 import io.envoyproxy.controlplane.server.serializer.DefaultProtoResourcesSerializer;
 import io.envoyproxy.controlplane.server.serializer.ProtoResourcesSerializer;
 import io.envoyproxy.envoy.api.v2.ClusterDiscoveryServiceGrpc.ClusterDiscoveryServiceImplBase;
@@ -19,34 +13,23 @@ import io.envoyproxy.envoy.api.v2.ListenerDiscoveryServiceGrpc.ListenerDiscovery
 import io.envoyproxy.envoy.api.v2.RouteDiscoveryServiceGrpc.RouteDiscoveryServiceImplBase;
 import io.envoyproxy.envoy.service.discovery.v2.AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceImplBase;
 import io.envoyproxy.envoy.service.discovery.v2.SecretDiscoveryServiceGrpc;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DiscoveryServer {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(DiscoveryServer.class);
-
   static final String ANY_TYPE_URL = "";
-
-  private final List<DiscoveryServerCallbacks> callbacks;
-  private final ConfigWatcher configWatcher;
+  private static final Logger LOGGER = LoggerFactory.getLogger(DiscoveryServer.class);
+  final List<DiscoveryServerCallbacks> callbacks;
+  final ConfigWatcher configWatcher;
+  final ProtoResourcesSerializer protoResourcesSerializer;
   private final ExecutorGroup executorGroup;
   private final AtomicLong streamCount = new AtomicLong();
-  private final ProtoResourcesSerializer protoResourcesSerializer;
 
   public DiscoveryServer(ConfigWatcher configWatcher) {
     this(Collections.emptyList(), configWatcher);
@@ -58,7 +41,8 @@ public class DiscoveryServer {
 
   /**
    * Creates the server.
-   * @param callbacks server callbacks
+   *
+   * @param callbacks     server callbacks
    * @param configWatcher source of configuration updates
    */
   public DiscoveryServer(List<DiscoveryServerCallbacks> callbacks, ConfigWatcher configWatcher) {
@@ -67,7 +51,8 @@ public class DiscoveryServer {
 
   /**
    * Creates the server.
-   * @param callbacks server callbacks
+   *
+   * @param callbacks     server callbacks
    * @param configWatcher source of configuration updates
    * @param executorGroup executor group to use for responding stream requests
    * @param protoResourcesSerializer serializer of proto buffer messages
@@ -162,7 +147,8 @@ public class DiscoveryServer {
    */
   public SecretDiscoveryServiceGrpc.SecretDiscoveryServiceImplBase getSecretDiscoveryServiceImpl() {
     return new SecretDiscoveryServiceGrpc.SecretDiscoveryServiceImplBase() {
-      @Override public StreamObserver<DiscoveryRequest> streamSecrets(
+      @Override
+      public StreamObserver<DiscoveryRequest> streamSecrets(
           StreamObserver<DiscoveryResponse> responseObserver) {
         return createRequestHandler(responseObserver, false, Resources.SECRET_TYPE_URL);
       }
@@ -181,177 +167,17 @@ public class DiscoveryServer {
 
     callbacks.forEach(cb -> cb.onStreamOpen(streamId, defaultTypeUrl));
 
-    final DiscoveryRequestStreamObserver requestStreamObserver =
-        new DiscoveryRequestStreamObserver(defaultTypeUrl, responseObserver, streamId, ads, executor);
+    final DiscoveryRequestStreamObserver requestStreamObserver;
+    if (ads) {
+      requestStreamObserver = new AdsDiscoveryRequestStreamObserver(defaultTypeUrl, responseObserver, streamId, executor, this);
+    } else {
+      requestStreamObserver = new XdsDiscoveryRequestStreamObserver(defaultTypeUrl, responseObserver, streamId, executor, this);
+    }
 
     if (responseObserver instanceof ServerCallStreamObserver) {
       ((ServerCallStreamObserver) responseObserver).setOnCancelHandler(requestStreamObserver::onCancelled);
     }
 
     return requestStreamObserver;
-  }
-
-  private class DiscoveryRequestStreamObserver implements StreamObserver<DiscoveryRequest> {
-
-    private final Map<String, Watch> watches;
-    private final Map<String, DiscoveryResponse> latestResponse;
-    private final Map<String, Set<String>> ackedResources;
-    private final String defaultTypeUrl;
-    private final StreamObserver<DiscoveryResponse> responseObserver;
-    private final long streamId;
-    private final boolean ads;
-    private final Executor executor;
-    private final AtomicBoolean isClosing = new AtomicBoolean();
-
-    private AtomicLong streamNonce;
-
-    public DiscoveryRequestStreamObserver(String defaultTypeUrl,
-                                          StreamObserver<DiscoveryResponse> responseObserver,
-                                          long streamId,
-                                          boolean ads,
-                                          Executor executor) {
-      this.defaultTypeUrl = defaultTypeUrl;
-      this.responseObserver = responseObserver;
-      this.streamId = streamId;
-      this.ads = ads;
-      watches = new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
-      latestResponse = new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
-      ackedResources = new ConcurrentHashMap<>(Resources.TYPE_URLS.size());
-      streamNonce = new AtomicLong();
-      this.executor = executor;
-    }
-
-    @Override
-    public void onNext(DiscoveryRequest request) {
-      String nonce = request.getResponseNonce();
-      String requestTypeUrl = request.getTypeUrl();
-
-      if (defaultTypeUrl.equals(ANY_TYPE_URL)) {
-        if (requestTypeUrl.isEmpty()) {
-          responseObserver.onError(
-              Status.UNKNOWN
-                  .withDescription(String.format("[%d] type URL is required for ADS", streamId))
-                  .asRuntimeException());
-
-          return;
-        }
-      } else if (requestTypeUrl.isEmpty()) {
-        requestTypeUrl = defaultTypeUrl;
-      }
-
-      LOGGER.debug("[{}] request {}[{}] with nonce {} from version {}",
-          streamId,
-          requestTypeUrl,
-          String.join(", ", request.getResourceNamesList()),
-          nonce,
-          request.getVersionInfo());
-
-      try {
-        callbacks.forEach(cb -> cb.onStreamRequest(streamId, request));
-      } catch (RequestException e) {
-        closeWithError(e);
-        return;
-      }
-
-      for (String typeUrl : Resources.TYPE_URLS) {
-        DiscoveryResponse response = latestResponse.get(typeUrl);
-        String resourceNonce = response == null ? null : response.getNonce();
-
-        if (requestTypeUrl.equals(typeUrl) && (isNullOrEmpty(resourceNonce)
-            || resourceNonce.equals(nonce))) {
-          if (!request.hasErrorDetail() && response != null) {
-            Set<String> ackedResourcesForType = response.getResourcesList()
-                .stream()
-                .map(Resources::getResourceName)
-                .collect(Collectors.toSet());
-            ackedResources.put(typeUrl, ackedResourcesForType);
-          }
-
-          watches.compute(typeUrl, (t, oldWatch) -> {
-            if (oldWatch != null) {
-              oldWatch.cancel();
-            }
-
-            return configWatcher.createWatch(
-                ads,
-                request,
-                ackedResources.getOrDefault(typeUrl, Collections.emptySet()),
-                r -> executor.execute(() -> send(r, typeUrl)));
-          });
-
-          return;
-        }
-      }
-    }
-
-    @Override
-    public void onError(Throwable t) {
-      if (!Status.fromThrowable(t).getCode().equals(Status.CANCELLED.getCode())) {
-        LOGGER.error("[{}] stream closed with error", streamId, t);
-      }
-
-      try {
-        callbacks.forEach(cb -> cb.onStreamCloseWithError(streamId, defaultTypeUrl, t));
-        responseObserver.onError(Status.fromThrowable(t).asException());
-      } finally {
-        cancel();
-      }
-    }
-
-    @Override
-    public void onCompleted() {
-      LOGGER.debug("[{}] stream closed", streamId);
-
-      try {
-        callbacks.forEach(cb -> cb.onStreamClose(streamId, defaultTypeUrl));
-        responseObserver.onCompleted();
-      } finally {
-        cancel();
-      }
-    }
-
-    void onCancelled() {
-      LOGGER.info("[{}] stream cancelled", streamId);
-      cancel();
-    }
-
-    private void closeWithError(Throwable exception) {
-      if (isClosing.compareAndSet(false, true)) {
-        responseObserver.onError(exception);
-      }
-      cancel();
-    }
-
-    private void cancel() {
-      watches.values().forEach(Watch::cancel);
-    }
-
-    private void send(Response response, String typeUrl) {
-      String nonce = Long.toString(streamNonce.getAndIncrement());
-
-      Collection<Any> resources = protoResourcesSerializer.serialize(response.resources());
-      DiscoveryResponse discoveryResponse = DiscoveryResponse.newBuilder()
-          .setVersionInfo(response.version())
-          .addAllResources(resources)
-          .setTypeUrl(typeUrl)
-          .setNonce(nonce)
-          .build();
-
-      LOGGER.debug("[{}] response {} with nonce {} version {}", streamId, typeUrl, nonce, response.version());
-
-      callbacks.forEach(cb -> cb.onStreamResponse(streamId, response.request(), discoveryResponse));
-
-      // Store the latest response *before* we send the response. This ensures that by the time the request
-      // is processed the map is guaranteed to be updated. Doing it afterwards leads to a race conditions
-      // which may see the incoming request arrive before the map is updated, failing the nonce check erroneously.
-      latestResponse.put(typeUrl, discoveryResponse);
-      try {
-        responseObserver.onNext(discoveryResponse);
-      } catch (StatusRuntimeException e) {
-        if (!Status.CANCELLED.getCode().equals(e.getStatus().getCode())) {
-          throw e;
-        }
-      }
-    }
   }
 }

--- a/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
@@ -63,10 +63,7 @@ public class XdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
 
   @Override
   void computeWatch(String typeUrl, Supplier<Watch> watchCreator) {
-    if (watch != null) {
-      watch.cancel();
-    }
-
+    cancel();
     watch = watchCreator.get();
   }
 }

--- a/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
@@ -1,7 +1,6 @@
 package io.envoyproxy.controlplane.server;
 
 import io.envoyproxy.controlplane.cache.Watch;
-import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
 import io.grpc.stub.StreamObserver;
 import java.util.Collections;
@@ -26,11 +25,6 @@ public class XdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
                                     DiscoveryServer discoveryServer) {
     super(defaultTypeUrl, responseObserver, streamId, executor, discoveryServer);
     this.ackedResources = Collections.emptySet();
-  }
-
-  @Override
-  public void onNext(DiscoveryRequest request) {
-    processRequest(defaultTypeUrl, request);
   }
 
   @Override

--- a/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
@@ -4,7 +4,6 @@ import io.envoyproxy.controlplane.cache.Watch;
 import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
 import io.grpc.stub.StreamObserver;
-
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.Executor;

--- a/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
@@ -9,9 +9,14 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
+/**
+ * {@code XdsDiscoveryRequestStreamObserver} is a lightweight implementation of {@link DiscoveryRequestStreamObserver}
+ * tailored for non-ADS streams which handle a single watch.
+ */
 public class XdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObserver {
   private volatile Watch watch;
   private volatile DiscoveryResponse latestResponse;
+  // ackedResources is only used in the same thread so it need not be volatile
   private Set<String> ackedResources;
 
   XdsDiscoveryRequestStreamObserver(String defaultTypeUrl,

--- a/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
@@ -1,0 +1,72 @@
+package io.envoyproxy.controlplane.server;
+
+import io.envoyproxy.controlplane.cache.Watch;
+import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
+import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
+import io.grpc.stub.StreamObserver;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+public class XdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObserver {
+  private volatile Watch watch;
+  private volatile DiscoveryResponse latestResponse;
+  private Set<String> ackedResources;
+
+  XdsDiscoveryRequestStreamObserver(String defaultTypeUrl,
+                                    StreamObserver<DiscoveryResponse> responseObserver,
+                                    long streamId,
+                                    Executor executor,
+                                    DiscoveryServer discoveryServer) {
+    super(defaultTypeUrl, responseObserver, streamId, executor, discoveryServer);
+    this.ackedResources = Collections.emptySet();
+  }
+
+  @Override
+  public void onNext(DiscoveryRequest request) {
+    processRequest(defaultTypeUrl, request);
+  }
+
+  @Override
+  void cancel() {
+    if (watch != null) {
+      watch.cancel();
+    }
+  }
+
+  @Override
+  boolean ads() {
+    return false;
+  }
+
+  @Override
+  DiscoveryResponse latestResponse(String typeUrl) {
+    return latestResponse;
+  }
+
+  @Override
+  void setLatestResponse(String typeUrl, DiscoveryResponse response) {
+    latestResponse = response;
+  }
+
+  @Override
+  Set<String> ackedResources(String typeUrl) {
+    return ackedResources;
+  }
+
+  @Override
+  void setAckedResources(String typeUrl, Set<String> resources) {
+    ackedResources = resources;
+  }
+
+  @Override
+  void computeWatch(String typeUrl, Supplier<Watch> watchCreator) {
+    if (watch != null) {
+      watch.cancel();
+    }
+
+    watch = watchCreator.get();
+  }
+}


### PR DESCRIPTION
The objective of this PR is to reduce the complexity and overhead when not operating in ADS mode.
When working with separate XDS streams the StreamObserver logic can be much simpler and it does not need to store maps, thus reducing the memory overhead.
This also includes a change in `Watch` and `StreamObserver` to use `Atomic*FieldUpdaters` instead of `Atomic*` which reduces the memory overhead per instance.

I realize this introduces a bit of indirection and probably code complexity, but this should be a win when not operating in ADS mode and having thousands of streams.