### PR TITLE
server: Cache serialized protos

### DIFF
--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
@@ -22,7 +22,6 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;

--- a/server/src/main/java/io/envoyproxy/controlplane/server/serializer/CachedProtoResourcesSerializer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/serializer/CachedProtoResourcesSerializer.java
@@ -1,0 +1,36 @@
+package io.envoyproxy.controlplane.server.serializer;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.protobuf.Any;
+import com.google.protobuf.Message;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+/**
+ * Cached version of the {@link ProtoResourcesSerializer}. It uses Guava Cache with weak values to store the serialized
+ * messages. The improvement especially visible when the same message is send to multiple Envoys (i.e. Edge Envoys).
+ * The message is then only serialized once as long as it's referenced anywhere else.
+ * Moreover, when the value is stored somewhere later, the same instance can be reused.
+ */
+public class CachedProtoResourcesSerializer implements ProtoResourcesSerializer {
+
+  private static final Cache<Collection<? extends Message>, List<Any>> cache = CacheBuilder.newBuilder()
+      .weakValues()
+      .build();
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Collection<Any> serialize(Collection<? extends Message> resources) {
+    try {
+      return cache.get(resources, () -> resources.stream().map(Any::pack).collect(Collectors.toList()));
+    } catch (ExecutionException e) {
+      throw new ProtoSerializerException("Error while serializing resources", e);
+    }
+  }
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/serializer/DefaultProtoResourcesSerializer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/serializer/DefaultProtoResourcesSerializer.java
@@ -3,9 +3,6 @@ package io.envoyproxy.controlplane.server.serializer;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 
-import java.util.Collection;
-import java.util.stream.Collectors;
-
 /**
  * Default implementation of ProtoResourcesSerializer that uses {@link Any#pack(Message)} method on {@link Message}.
  */
@@ -15,9 +12,7 @@ public class DefaultProtoResourcesSerializer implements ProtoResourcesSerializer
    * {@inheritDoc}
    */
   @Override
-  public Collection<Any> serialize(Collection<? extends Message> resources) {
-    return resources.stream()
-        .map(Any::pack)
-        .collect(Collectors.toList());
+  public Any serialize(Message resource) {
+    return Any.pack(resource);
   }
 }

--- a/server/src/main/java/io/envoyproxy/controlplane/server/serializer/DefaultProtoResourcesSerializer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/serializer/DefaultProtoResourcesSerializer.java
@@ -1,0 +1,23 @@
+package io.envoyproxy.controlplane.server.serializer;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.Message;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ * Default implementation of ProtoResourcesSerializer that uses {@link Any#pack(Message)} method on {@link Message}.
+ */
+public class DefaultProtoResourcesSerializer implements ProtoResourcesSerializer {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Collection<Any> serialize(Collection<? extends Message> resources) {
+    return resources.stream()
+        .map(Any::pack)
+        .collect(Collectors.toList());
+  }
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/serializer/ProtoResourcesSerializer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/serializer/ProtoResourcesSerializer.java
@@ -4,6 +4,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 /**
  * Serializer of the proto buffers resource messages.
@@ -15,7 +16,16 @@ public interface ProtoResourcesSerializer {
    * @param resources list of resources to serialize
    * @return serialized resources
    */
-  Collection<Any> serialize(Collection<? extends Message> resources);
+  default Collection<Any> serialize(Collection<? extends Message> resources) {
+    return resources.stream().map(this::serialize).collect(Collectors.toList());
+  }
+
+  /**
+   * Serialize message to proto buffers.
+   * @param resource the resource to serialize
+   * @return serialized resource
+   */
+  Any serialize(Message resource);
 
   class ProtoSerializerException extends RuntimeException {
     ProtoSerializerException(String message, Throwable cause) {

--- a/server/src/main/java/io/envoyproxy/controlplane/server/serializer/ProtoResourcesSerializer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/serializer/ProtoResourcesSerializer.java
@@ -1,0 +1,25 @@
+package io.envoyproxy.controlplane.server.serializer;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.Message;
+
+import java.util.Collection;
+
+/**
+ * Serializer of the proto buffers resource messages.
+ */
+public interface ProtoResourcesSerializer {
+
+  /**
+   * Serialize messages to proto buffers.
+   * @param resources list of resources to serialize
+   * @return serialized resources
+   */
+  Collection<Any> serialize(Collection<? extends Message> resources);
+
+  class ProtoSerializerException extends RuntimeException {
+    ProtoSerializerException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/server/src/test/java/io/envoyproxy/controlplane/server/serializer/CachedProtoResourcesSerializerTest.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/serializer/CachedProtoResourcesSerializerTest.java
@@ -15,7 +15,18 @@ public class CachedProtoResourcesSerializerTest {
 
   @Test
   public void shouldKeepCachedProtoWhenSerializingSameMessage() {
-    // given
+    ClusterLoadAssignment endpoint = ClusterLoadAssignment.newBuilder()
+        .setClusterName("service1")
+        .build();
+
+    Any serializedEndpoint = serializer.serialize(endpoint);
+    Any serializedSameEndpoint = serializer.serialize(endpoint);
+
+    assertThat(serializedEndpoint).isSameAs(serializedSameEndpoint);
+  }
+
+  @Test
+  public void shouldKeepCachedProtoWhenSerializingSameMessages() {
     List<ClusterLoadAssignment> endpoints = Lists.newArrayList(
         ClusterLoadAssignment.newBuilder()
             .setClusterName("service1")
@@ -25,11 +36,13 @@ public class CachedProtoResourcesSerializerTest {
             .build()
     );
 
-    // when
     Collection<Any> serializedEndpoints = serializer.serialize(endpoints);
     Collection<Any> serializedSameEndpoints = serializer.serialize(endpoints);
 
-    // then
-    assertThat(serializedEndpoints).isSameAs(serializedSameEndpoints);
+    assertThat(serializedEndpoints).isEqualTo(serializedSameEndpoints);
+    assertThat(serializedEndpoints).isNotSameAs(serializedSameEndpoints);
+    assertThat(serializedEndpoints) // elements are the same instances
+        .usingElementComparator((x, y) -> x == y ? 0 : 1)
+        .hasSameElementsAs(serializedSameEndpoints);
   }
 }

--- a/server/src/test/java/io/envoyproxy/controlplane/server/serializer/CachedProtoResourcesSerializerTest.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/serializer/CachedProtoResourcesSerializerTest.java
@@ -1,0 +1,35 @@
+package io.envoyproxy.controlplane.server.serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Lists;
+import com.google.protobuf.Any;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import java.util.Collection;
+import java.util.List;
+import org.junit.Test;
+
+public class CachedProtoResourcesSerializerTest {
+
+  CachedProtoResourcesSerializer serializer = new CachedProtoResourcesSerializer();
+
+  @Test
+  public void shouldKeepCachedProtoWhenSerializingSameMessage() {
+    // given
+    List<ClusterLoadAssignment> endpoints = Lists.newArrayList(
+        ClusterLoadAssignment.newBuilder()
+            .setClusterName("service1")
+            .build(),
+        ClusterLoadAssignment.newBuilder()
+            .setClusterName("service2")
+            .build()
+    );
+
+    // when
+    Collection<Any> serializedEndpoints = serializer.serialize(endpoints);
+    Collection<Any> serializedSameEndpoints = serializer.serialize(endpoints);
+
+    // then
+    assertThat(serializedEndpoints).isSameAs(serializedSameEndpoints);
+  }
+}

--- a/server/src/test/java/io/envoyproxy/controlplane/server/serializer/DefaultProtoResourcesSerializerTest.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/serializer/DefaultProtoResourcesSerializerTest.java
@@ -1,0 +1,36 @@
+package io.envoyproxy.controlplane.server.serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Lists;
+import com.google.protobuf.Any;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import java.util.Collection;
+import java.util.List;
+import org.junit.Test;
+
+public class DefaultProtoResourcesSerializerTest {
+
+  DefaultProtoResourcesSerializer serializer = new DefaultProtoResourcesSerializer();
+
+  @Test
+  public void shouldReturnDifferentInstanceOfSerializedProtoWhenResourcesAreTheSame() {
+    // given
+    List<ClusterLoadAssignment> endpoints = Lists.newArrayList(
+        ClusterLoadAssignment.newBuilder()
+            .setClusterName("service1")
+            .build(),
+        ClusterLoadAssignment.newBuilder()
+            .setClusterName("service2")
+            .build()
+    );
+
+    // when
+    Collection<Any> serializedEndpoints = serializer.serialize(endpoints);
+    Collection<Any> serializedSameEndpoints = serializer.serialize(endpoints);
+
+    // then
+    assertThat(serializedEndpoints).isEqualTo(serializedSameEndpoints);
+    assertThat(serializedEndpoints).isNotSameAs(serializedSameEndpoints);
+  }
+}

--- a/server/src/test/java/io/envoyproxy/controlplane/server/serializer/DefaultProtoResourcesSerializerTest.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/serializer/DefaultProtoResourcesSerializerTest.java
@@ -15,7 +15,19 @@ public class DefaultProtoResourcesSerializerTest {
 
   @Test
   public void shouldReturnDifferentInstanceOfSerializedProtoWhenResourcesAreTheSame() {
-    // given
+    ClusterLoadAssignment endpoint = ClusterLoadAssignment.newBuilder()
+        .setClusterName("service1")
+        .build();
+
+    Any serializedEndpoint = serializer.serialize(endpoint);
+    Any serializedSameEndpoint = serializer.serialize(endpoint);
+
+    assertThat(serializedEndpoint).isEqualTo(serializedSameEndpoint);
+    assertThat(serializedEndpoint).isNotSameAs(serializedSameEndpoint);
+  }
+
+  @Test
+  public void shouldReturnDifferentInstancesOfSerializedProtoWhenResourcesAreTheSame() {
     List<ClusterLoadAssignment> endpoints = Lists.newArrayList(
         ClusterLoadAssignment.newBuilder()
             .setClusterName("service1")
@@ -25,12 +37,13 @@ public class DefaultProtoResourcesSerializerTest {
             .build()
     );
 
-    // when
     Collection<Any> serializedEndpoints = serializer.serialize(endpoints);
     Collection<Any> serializedSameEndpoints = serializer.serialize(endpoints);
 
-    // then
     assertThat(serializedEndpoints).isEqualTo(serializedSameEndpoints);
     assertThat(serializedEndpoints).isNotSameAs(serializedSameEndpoints);
+    assertThat(serializedEndpoints) // elements are not the same instances
+        .usingElementComparator((x, y) -> x == y ? 0 : 1)
+        .doesNotContainAnyElementsOf(serializedSameEndpoints);
   }
 }


### PR DESCRIPTION
During the java-control-plane performance debugging I've noticed that the proto with resources is built on every response which is then stored in the `lastResponse`. This is huge pressure on GC when you run java-control-plane with many Envoys that receives the same set of resources (for example: edge envoys).

That is why I introduced Guava cache with `weakValues()`. So as long as any `DiscoveryRequestStreamObserver#lastResponse` will keep the value, it will be served from the cache. Otherwise it will be wiped with the next GC.

I run the test when connected to 300 envoys on ADS on single instance of our control plane. Every envoy gets all the state of our discovery which is ~700 clusters and couple of thousands endpoints. Here is the result
![image copy](https://user-images.githubusercontent.com/5459824/54540234-ec9b4980-4997-11e9-8a84-264d620bf693.png)
Before this change is the instance with green line. On the right is the instance with this change. As you can see, this is a huge improvement on the performance.

I think that this "feature" should be internal, that's why I've made `ProtoResourcesSerializer` package private and static. If you are afraid that it will break something I can change it to the interface, introduce `DefaultProtoResourcesSerializer` which will keep current behaviour and `CacheProtoResourcesSerializer` which will has the cache. Then add another parameter to the `DiscoveryServer` constructor.

Signed-off-by: Jakub Dyszkiewicz <jakub.dyszkiewicz@allegro.pl>