### PR TITLE
deps: bring all dependencies up to date

### DIFF
--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -31,6 +31,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.envoyproxy.controlplane</groupId>
             <artifactId>api</artifactId>
             <version>0.1.15-SNAPSHOT</version>

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/Resources.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/Resources.java
@@ -146,6 +146,7 @@ public class Resources {
             try {
               HttpConnectionManager.Builder config = HttpConnectionManager.newBuilder();
 
+              // TODO: Filter#getConfig() is deprecated, migrate to use Filter#getTypedConfig().
               structAsMessage(filter.getConfig(), config);
 
               if (config.getRouteSpecifierCase() == RDS && !isNullOrEmpty(config.getRds().getRouteConfigName())) {

--- a/pom.xml
+++ b/pom.xml
@@ -23,16 +23,17 @@
 
         <!-- Dependency Versions -->
         <annotation-api.version>1.3.2</annotation-api.version>
-        <assertj.version>3.10.0</assertj.version>
-        <auto-value.version>1.6</auto-value.version>
-        <awaitility.version>3.1.0</awaitility.version>
-        <checkstyle.version>8.8</checkstyle.version>
-        <grpc.version>1.12.0</grpc.version>
-        <guava.version>20.0</guava.version>
+        <assertj.version>3.12.2</assertj.version>
+        <auto-value.version>1.6.3</auto-value.version>
+        <awaitility.version>3.1.6</awaitility.version>
+        <checkstyle.version>8.18</checkstyle.version>
+        <grpc.version>1.19.0</grpc.version>
+        <guava.version>26.0-android</guava.version><!-- Keep the Guava version in sync with grpc-java -->
         <junit.version>4.12</junit.version>
+        <protobuf.version>3.6.1</protobuf.version><!-- Keep the Protobuf version in sync with grpc-java -->
         <rest-assured.version>3.1.0</rest-assured.version>
-        <slf4j.version>1.7.25</slf4j.version>
-        <testcontainers.version>1.7.3</testcontainers.version>
+        <slf4j.version>1.7.26</slf4j.version>
+        <testcontainers.version>1.10.7</testcontainers.version>
 
         <!-- Maven Plugin Versions -->
         <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
@@ -43,6 +44,7 @@
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
     </properties>
 
     <name>java-control-plane</name>
@@ -209,6 +211,12 @@
                             <autoVersionSubmodules>true</autoVersionSubmodules>
                             <tagNameFormat>v@{project.version}</tagNameFormat>
                         </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>versions-maven-plugin</artifactId>
+                        <version>${versions-maven-plugin.version}</version>
                     </plugin>
 
                     <plugin>


### PR DESCRIPTION
Checkstyle needs to be updated to resolve a CVE (https://nvd.nist.gov/vuln/detail/CVE-2019-9658). In the process, I also went ahead and brought everything else up to date. Any dependencies that are shared transitively with grpc-java have been set to the version used by grpc-java, even if there is a newer stable version available.

Also, grpc-java no longer transitively depends on protobuf-java-util, so we need to explicitly add it ourselves.