### PR TITLE
server: introducing DDoS prevention mechanisms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/FlowControl.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/FlowControl.java
@@ -2,6 +2,12 @@ package io.envoyproxy.controlplane.server.limits;
 
 import io.grpc.stub.StreamObserver;
 
+/**
+ * Strategy for controlling the flow control of requests in the GRPC bidirectional request-response flow.
+ * <p>The interface assumes a blocking GRPC API is being used as implementations are free to block the thread until
+ * the flow is allowed to continue processing next request.</p>
+ * @param <V> The response type of the controlled stream.
+ */
 public interface FlowControl<V> {
 
   void streamOpened();

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/FlowControl.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/FlowControl.java
@@ -1,0 +1,23 @@
+package io.envoyproxy.controlplane.server.limits;
+
+import io.grpc.stub.StreamObserver;
+
+public interface FlowControl<V> {
+
+  void streamOpened();
+
+  void streamClosed();
+
+  void afterRequest();
+
+  @FunctionalInterface
+  interface Factory<V> {
+    FlowControl<V> get(long streamId,
+                       StreamObserver<V> serverCallStreamObserver,
+                       RequestLimiter requestLimiter);
+  }
+
+  static <T> Factory<T> noOpFactory() {
+    return (streamId, stream, limiter) -> new NoOpFlowControl<>();
+  }
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/GuavaRequestLimiter.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/GuavaRequestLimiter.java
@@ -2,9 +2,17 @@ package io.envoyproxy.controlplane.server.limits;
 
 import com.google.common.util.concurrent.RateLimiter;
 
+/**
+ * {@link RequestLimiter} which delegates permit acquisition to Guava's {@link RateLimiter}.
+ */
 public class GuavaRequestLimiter implements RequestLimiter {
+
   private final RateLimiter rateLimiter;
 
+  /**
+   * {@link RequestLimiter} delegating to Guava's {@link RateLimiter}.
+   * @param rateLimiter instance of Guava's rate limiter configured by the user.
+   */
   public GuavaRequestLimiter(RateLimiter rateLimiter) {
     this.rateLimiter = rateLimiter;
   }

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/GuavaRequestLimiter.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/GuavaRequestLimiter.java
@@ -1,0 +1,16 @@
+package io.envoyproxy.controlplane.server.limits;
+
+import com.google.common.util.concurrent.RateLimiter;
+
+public class GuavaRequestLimiter implements RequestLimiter {
+  private final RateLimiter rateLimiter;
+
+  public GuavaRequestLimiter(RateLimiter rateLimiter) {
+    this.rateLimiter = rateLimiter;
+  }
+
+  @Override
+  public void acquire() {
+    rateLimiter.acquire();
+  }
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/ManualFlowControl.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/ManualFlowControl.java
@@ -6,16 +6,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * {@link FlowControl} implementation that utilizes HTTP2 back-pressure and request limiting according to user-provided
+ * strategy.
+ * <p>It assumes {@link ServerCallStreamObserver} implementation, which is required for manual flow control.</p>
+ */
 public class ManualFlowControl implements FlowControl<DiscoveryResponse> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ManualFlowControl.class);
 
   private final long streamId;
-
   private final ServerCallStreamObserver<DiscoveryResponse> serverCallStreamObserver;
-
   private final AtomicBoolean observerWasReady = new AtomicBoolean(false);
-
   private final RequestLimiter requestLimiter;
 
   /**

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/ManualFlowControl.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/ManualFlowControl.java
@@ -1,0 +1,78 @@
+package io.envoyproxy.controlplane.server.limits;
+
+import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
+import io.grpc.stub.ServerCallStreamObserver;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ManualFlowControl implements FlowControl<DiscoveryResponse> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ManualFlowControl.class);
+
+  private final long streamId;
+
+  private final ServerCallStreamObserver<DiscoveryResponse> serverCallStreamObserver;
+
+  private final AtomicBoolean observerWasReady = new AtomicBoolean(false);
+
+  private final RequestLimiter requestLimiter;
+
+  /**
+   * Flow Control implementation that considers back-pressure and request limiting.
+   * @param streamId ID of the stream
+   * @param serverCallStreamObserver the response observer which allows to control the client's readiness
+   * @param requestLimiter a synchronous limiter
+   */
+  public ManualFlowControl(long streamId,
+                           ServerCallStreamObserver<DiscoveryResponse> serverCallStreamObserver,
+                           RequestLimiter requestLimiter) {
+    this.streamId = streamId;
+    this.serverCallStreamObserver = serverCallStreamObserver;
+    this.requestLimiter = requestLimiter;
+  }
+
+  @Override
+  public void streamOpened() {
+    serverCallStreamObserver.disableAutoInboundFlowControl();
+    serverCallStreamObserver.setOnReadyHandler(() -> {
+      if (serverCallStreamObserver.isReady() && observerWasReady.compareAndSet(false, true)) {
+        LOGGER.debug("[{}] stream ready", streamId);
+        serverCallStreamObserver.request(1);
+      }
+    });
+  }
+
+  @Override
+  public void streamClosed() {
+  }
+
+  @Override
+  public void afterRequest() {
+    if (serverCallStreamObserver.isReady()) {
+      requestLimiter.acquire();
+      serverCallStreamObserver.request(1);
+    } else {
+      LOGGER.debug("[{}] stream not ready", streamId);
+      observerWasReady.set(false);
+    }
+  }
+
+  /**
+   * Factory that creates a {@link ManualFlowControl} instance and validates
+   * that it's used with a stream observer compatible with manually controlling the flow.
+   * @return {@link ManualFlowControl instance}
+   */
+  public static Factory<DiscoveryResponse> factory() {
+    return (streamId, stream, limiter) -> {
+      if (!(stream instanceof ServerCallStreamObserver)) {
+        throw new IllegalArgumentException(
+            "ManualFlowControl can only be used with ServerCallStreamObserver."
+        );
+      }
+      return new ManualFlowControl(
+          streamId, (ServerCallStreamObserver<DiscoveryResponse>) stream, limiter
+      );
+    };
+  }
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/NoOpFlowControl.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/NoOpFlowControl.java
@@ -1,0 +1,16 @@
+package io.envoyproxy.controlplane.server.limits;
+
+public class NoOpFlowControl<V> implements FlowControl<V> {
+
+  @Override
+  public void streamOpened() {
+  }
+
+  @Override
+  public void streamClosed() {
+  }
+
+  @Override
+  public void afterRequest() {
+  }
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/NoOpFlowControl.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/NoOpFlowControl.java
@@ -1,5 +1,10 @@
 package io.envoyproxy.controlplane.server.limits;
 
+/**
+ * {@link FlowControl} implementation that effectively doesn't influence the default flow control implementation
+ * provided by grpc-java (automatic).
+ * @param <V> The response type of the controlled stream.
+ */
 public class NoOpFlowControl<V> implements FlowControl<V> {
 
   @Override

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/NoOpRequestLimiter.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/NoOpRequestLimiter.java
@@ -1,7 +1,12 @@
 package io.envoyproxy.controlplane.server.limits;
 
+/**
+ * {@link RequestLimiter} that always permits next request to be processed straight away and does not block the thread.
+ */
 public class NoOpRequestLimiter implements RequestLimiter {
+
   @Override
   public void acquire() {
   }
+
 }

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/NoOpRequestLimiter.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/NoOpRequestLimiter.java
@@ -1,0 +1,7 @@
+package io.envoyproxy.controlplane.server.limits;
+
+public class NoOpRequestLimiter implements RequestLimiter {
+  @Override
+  public void acquire() {
+  }
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/RequestLimiter.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/RequestLimiter.java
@@ -1,0 +1,5 @@
+package io.envoyproxy.controlplane.server.limits;
+
+public interface RequestLimiter {
+  void acquire();
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/RequestLimiter.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/RequestLimiter.java
@@ -1,5 +1,8 @@
 package io.envoyproxy.controlplane.server.limits;
 
+/**
+ * Blocking interface for limiting requests flow in a bidirectional GRPC stream.
+ */
 public interface RequestLimiter {
   void acquire();
 }

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/StreamLimiter.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/StreamLimiter.java
@@ -10,14 +10,15 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A provider of {@link ServerInterceptor} for limiting concurrently handled GRPC streams.
+ */
 public class StreamLimiter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StreamLimiter.class);
 
   private final long maxStreams;
-
   private final ServerInterceptor serverInterceptor;
-
   private final AtomicLong openStreams = new AtomicLong();
 
   /**

--- a/server/src/main/java/io/envoyproxy/controlplane/server/limits/StreamLimiter.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/limits/StreamLimiter.java
@@ -1,0 +1,85 @@
+package io.envoyproxy.controlplane.server.limits;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StreamLimiter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StreamLimiter.class);
+
+  private final long maxStreams;
+
+  private final ServerInterceptor serverInterceptor;
+
+  private final AtomicLong openStreams = new AtomicLong();
+
+  /**
+   * StreamLimiter is responsible for configuring a {@link ServerInterceptor} instance,
+   * which will take care of limiting concurrently open streams.
+   * @param maxStreams the upper limit for concurrently open streams
+   */
+  public StreamLimiter(long maxStreams) {
+    this.maxStreams = maxStreams;
+    this.serverInterceptor = new ServerInterceptor() {
+      @Override
+      public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+          ServerCall<ReqT, RespT> call,
+          Metadata headers,
+          ServerCallHandler<ReqT, RespT> next
+      ) {
+        if (openStreams.get() >= maxStreams) {
+          call.close(Status.UNAVAILABLE, new Metadata());
+          return new ServerCall.Listener<ReqT>() {};
+        }
+
+        final Listener<ReqT> delegate = next.startCall(call, headers);
+
+        openStreams.incrementAndGet();
+
+        LOGGER.debug("stream opened [open/max: {} / {}]", openStreams.get(), maxStreams);
+
+        return new Listener<ReqT>() {
+          @Override
+          public void onMessage(ReqT message) {
+            delegate.onMessage(message);
+          }
+
+          @Override
+          public void onHalfClose() {
+            delegate.onHalfClose();
+          }
+
+          @Override
+          public void onCancel() {
+            openStreams.decrementAndGet();
+            LOGGER.debug("stream canceled [open/max: {} / {}]", openStreams.get(), maxStreams);
+            delegate.onCancel();
+          }
+
+          @Override
+          public void onComplete() {
+            openStreams.decrementAndGet();
+            LOGGER.debug("stream complete [open/max: {} / {}]", openStreams.get(), maxStreams);
+            delegate.onComplete();
+          }
+
+          @Override
+          public void onReady() {
+            delegate.onReady();
+          }
+        };
+      }
+    };
+  }
+
+  public ServerInterceptor getServerInterceptor() {
+    return this.serverInterceptor;
+  }
+}

--- a/server/src/test/java/io/envoyproxy/controlplane/server/TestLimits.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/TestLimits.java
@@ -1,0 +1,111 @@
+package io.envoyproxy.controlplane.server;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.RateLimiter;
+import com.google.protobuf.Duration;
+import io.envoyproxy.controlplane.cache.SimpleCache;
+import io.envoyproxy.controlplane.cache.Snapshot;
+import io.envoyproxy.controlplane.server.limits.GuavaRequestLimiter;
+import io.envoyproxy.controlplane.server.limits.ManualFlowControl;
+import io.envoyproxy.controlplane.server.limits.StreamLimiter;
+import io.envoyproxy.envoy.api.v2.Cluster;
+import io.envoyproxy.envoy.api.v2.Cluster.DiscoveryType;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import io.envoyproxy.envoy.api.v2.core.Address;
+import io.envoyproxy.envoy.api.v2.core.SocketAddress;
+import io.envoyproxy.envoy.api.v2.endpoint.Endpoint;
+import io.envoyproxy.envoy.api.v2.endpoint.LbEndpoint;
+import io.envoyproxy.envoy.api.v2.endpoint.LocalityLbEndpoints;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.netty.NettyServerBuilder;
+import java.io.IOException;
+
+public class TestLimits {
+
+  private static final String GROUP = "key";
+
+  private static final long MAX_OPEN_STREAMS = 10;
+  private static final long MAX_RPS = 1;
+
+  private static final Snapshot CLUSTER_0_SNAPSHOT = Snapshot.create(
+      ImmutableList.of(
+          Cluster.newBuilder()
+              .setName("cluster0")
+              .setConnectTimeout(Duration.newBuilder().setSeconds(5))
+              .setType(DiscoveryType.STATIC)
+              .setLoadAssignment(loadAssignment("127.0.0.1", 1234))
+              .build()),
+      ImmutableList.of(),
+      ImmutableList.of(),
+      ImmutableList.of(),
+      ImmutableList.of(),
+      "1");
+
+  private static final Snapshot CLUSTER_1_SNAPSHOT = Snapshot.create(
+      ImmutableList.of(
+          Cluster.newBuilder()
+              .setName("cluster1")
+              .setConnectTimeout(Duration.newBuilder().setSeconds(5))
+              .setType(DiscoveryType.STATIC)
+              .setLoadAssignment(loadAssignment("127.0.0.1", 1235))
+              .build()),
+      ImmutableList.of(),
+      ImmutableList.of(),
+      ImmutableList.of(),
+      ImmutableList.of(),
+      "1");
+
+  /**
+   * Example minimal xDS implementation using the java-control-plane lib.
+   * Additionally, this example includes the below configuration:
+   * <ul>
+   *   <li>Total RPS limit,</li>
+   *   <li>Concurrently opened streams limit,</li>
+   *   <li>HTTP2 based flow control back-pressure.</li>
+   * </ul>
+   *
+   * @param arg command-line args
+   */
+  public static void main(String[] arg) throws IOException, InterruptedException {
+    SimpleCache<String> cache = new SimpleCache<>(node -> GROUP);
+    cache.setSnapshot(GROUP, CLUSTER_0_SNAPSHOT);
+
+    DiscoveryServer discoveryServer = DiscoveryServer.watching(cache)
+        .withFlowControlFactory(ManualFlowControl.factory())
+        .withRequestLimiter(new GuavaRequestLimiter(RateLimiter.create(MAX_RPS)))
+        .build();
+
+    ServerBuilder builder = NettyServerBuilder.forPort(12345)
+        .addService(discoveryServer.getAggregatedDiscoveryServiceImpl())
+        .addService(discoveryServer.getClusterDiscoveryServiceImpl())
+        .addService(discoveryServer.getEndpointDiscoveryServiceImpl())
+        .addService(discoveryServer.getListenerDiscoveryServiceImpl())
+        .addService(discoveryServer.getRouteDiscoveryServiceImpl());
+
+    builder.intercept(new StreamLimiter(MAX_OPEN_STREAMS).getServerInterceptor());
+
+    Server server = builder.build();
+    server.start();
+
+    System.out.println("Server has started on port " + server.getPort());
+
+    Runtime.getRuntime().addShutdownHook(new Thread(server::shutdown));
+
+    Thread.sleep(10000);
+
+    cache.setSnapshot(GROUP, CLUSTER_1_SNAPSHOT);
+
+    server.awaitTermination();
+  }
+
+  private static ClusterLoadAssignment loadAssignment(String ip, int port) {
+    return ClusterLoadAssignment.newBuilder().addEndpoints(
+        LocalityLbEndpoints.newBuilder().addLbEndpoints(LbEndpoint.newBuilder().setEndpoint(
+            Endpoint.newBuilder().setAddress(
+                Address.newBuilder()
+                    .setSocketAddress(
+                        SocketAddress.newBuilder().setAddress(ip).setPortValue(port))
+            ).build()).build()).build()).build();
+  }
+}


### PR DESCRIPTION
As described in #101 – I'm suggesting adding a DDoS prevention layer and this is an attempt to address this issue.

The work done here is partly based on the example implementation of [manual flow control in grpc-java](https://github.com/grpc/grpc-java/blob/master/examples/src/main/java/io/grpc/examples/manualflowcontrol/ManualFlowControlServer.java).

I tried making everything customizable and pluggable. The existing usages of `java-control-plane` should not be affected by these changes and will be available upon using classes in the`limits` package as depicted in `TestLimits` runner.

To perform load tests I used [ghz](https://github.com/bojand/ghz). Here is the configuration and a run command:

```
{
  "proto": "proto/cds.proto",
  "importPaths": "proto",
  "call": "envoy.api.v2.ClusterDiscoveryService/StreamClusters",
  "n": 45,
  "c": 15,
  "t": 60,
  "host": "0.0.0.0:12345",
  "insecure": true,
  "d": {
    "node": {
      "id": "myself",
      "cluster": "somecluster",
      "metadata": {},
      "locality": {
        "region": "unknown",
        "zone": "one",
        "sub_zone": ""
      }
    },
    "resource_names": [],
    "response_nonce": "",
    "type_url": "type.googleapis.com/envoy.api.v2.Cluster"
  }
}
```

```ghz -config java-control-plane-loadtest.json```

To run this, I copied over the `proto` folder into my testing directory.

What this configuration does:

- Opens 45 streams,
- Concurrently sends 15 requests,
- Times out a stream after 60 seconds,
- For each stream it sends an initial CDS request.

With the `TestLimits` configuration of

- 1 RPS rate limit,
- 10 concurrent streams.

This test takes around 30s to finish and results in 15 streams not being handled.

ghz's output:

```
Summary:
  Count:	45
  Total:	28.01 s
  Slowest:	10.00 s
  Fastest:	6.27 ms
  Average:	5.23 s
  Requests/sec:	1.61

Response time histogram:
  6.272 [1]	|∎∎
  1006.015 [1]	|∎∎
  2005.759 [1]	|∎∎
  3005.502 [1]	|∎∎
  4005.245 [1]	|∎∎
  5004.988 [1]	|∎∎
  6004.731 [1]	|∎∎
  7004.474 [1]	|∎∎
  8004.218 [1]	|∎∎
  9003.961 [2]	|∎∎∎∎
  10003.704 [19]	|∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎

Latency distribution:
  10% in 2.01 s
  25% in 7.01 s
  50% in 10.00 s
  75% in 10.00 s
  90% in 10.00 s
  95% in 10.00 s
  0% in 0 ns
Status code distribution:
  [OK]            30 responses
  [Unavailable]   15 responses

Error distribution:
  [15]   rpc error: code = Unavailable desc =
```

Regarding code coverage. I tried doing my best, but due to the nature of `ServerCallStreamObserver` and the hidden default implementation, mocking it would miss the point in my opinion. When it comes to the part of limiting concurrently open streams, I tried depicting it in `TestLimits` runner and providing a load test configuration. I'm open to suggestions if you have better ideas for automated tests that I can add.

Fixes #101 