### PR TITLE
server: return custom error response for invalid DiscoveryRequest

### DIFF
--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServerCallbacks.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServerCallbacks.java
@@ -1,5 +1,6 @@
 package io.envoyproxy.controlplane.server;
 
+import io.envoyproxy.controlplane.server.exception.RequestException;
 import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
 import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
 
@@ -48,6 +49,9 @@ public interface DiscoveryServerCallbacks {
    *
    * @param streamId an ID for this stream that is only unique to this discovery server instance
    * @param request the discovery request sent by the envoy instance
+   *
+   * @throws RequestException optionally can throw {@link RequestException} with custom status. That status
+   *     will be returned to the client and the stream will be closed with error.
    */
   default void onStreamRequest(long streamId, DiscoveryRequest request) {
 

--- a/server/src/main/java/io/envoyproxy/controlplane/server/exception/RequestException.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/exception/RequestException.java
@@ -1,0 +1,17 @@
+package io.envoyproxy.controlplane.server.exception;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+
+import javax.annotation.Nullable;
+
+public class RequestException extends StatusRuntimeException {
+  public RequestException(Status status) {
+    this(status, null);
+  }
+
+  public RequestException(Status status, @Nullable Metadata trailers) {
+    super(status, trailers);
+  }
+}


### PR DESCRIPTION
This PR adds possibility to validate DiscoveryRequest and return custom error response to the client.

Envoy will show our custom status code and description in logs with `warning` level:
```
gRPC config stream closed: 3, custom validation error message
```
instead of generic:
```
gRPC config stream closed: 2, 
```

Fixes #104 