### PR TITLE
build: deprecate envoy-java-control-plane-bot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ jobs:
               shred signing-key
 
               if [[ -n "${RELEASE}" && -n "${NEXT}" ]]; then
-                git config --global user.email "36644060+envoy-java-control-plane-bot@users.noreply.github.com"
-                git config --global user.name "envoy-java-control-plane-bot"
+                git config --global user.email "envoy-bot@users.noreply.github.com"
+                git config --global user.name "envoy-bot"
                 mvn -B -s .circleci/settings.xml release:prepare -Darguments="-s .circleci/settings.xml" -DreleaseVersion=$RELEASE -DdevelopmentVersion=$NEXT -DscmCommentPrefix="release: "
               else
                 mvn -B -s .circleci/settings.xml deploy


### PR DESCRIPTION
Similar to the protoc-gen-validate build, use the shared envoy-bot user rather than our envoy-java-control-plane-bot user.

Signed-off-by: Joey Bratton <jbratton@salesforce.com>