### PR TITLE
docs: add Allegro team members to OWNERS.md

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -8,3 +8,6 @@
 * Rama Chavali ([ramaraochavali](https://github.com/ramaraochavali)) (rama.rao@salesforce.com)
 * Ben Hoyt ([b-hoyt](https://github.com/b-hoyt)) (bhoyt@salesforce.com)
 * Snow Pettersen ([snowp](https://github.com/snowp)) (snowp@squareup.com)
+* Dariusz Jędrzejczyk ([chemicL](https://github.com/chemicL)) (dariusz.jedrzejczyk@allegro.pl)
+* Jakub Dyszkiewicz ([jakubdyszkiewicz](https://github.com/jakubdyszkiewicz)) (jakub.dyszkiewicz@allegro.pl)
+* Krzysztof Słonka ([slonka](https://github.com/slonka)) (krzysztof.slonka@allegro.pl)


### PR DESCRIPTION
As discussed over the envoy-maintainers thread, please allow adding myself, @jakubdyszkiewicz and @slonka to the OWNERS.md file.