### PR TITLE
Synchronize access to responseObserver

### DIFF
--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServer.java
@@ -228,15 +228,10 @@ public class DiscoveryServer {
 
       if (defaultTypeUrl.equals(ANY_TYPE_URL)) {
         if (requestTypeUrl.isEmpty()) {
-          synchronized (responseObserver) {
-            if (!isClosing) {
-              isClosing = true;
-              responseObserver.onError(
-                  Status.UNKNOWN
-                      .withDescription(String.format("[%d] type URL is required for ADS", streamId))
-                      .asRuntimeException());
-            }
-          }
+          closeWithError(
+              Status.UNKNOWN
+                  .withDescription(String.format("[%d] type URL is required for ADS", streamId))
+                  .asRuntimeException());
 
           return;
         }
@@ -297,12 +292,7 @@ public class DiscoveryServer {
 
       try {
         callbacks.forEach(cb -> cb.onStreamCloseWithError(streamId, defaultTypeUrl, t));
-        synchronized (responseObserver) {
-          if (!isClosing) {
-            isClosing = true;
-            responseObserver.onError(Status.fromThrowable(t).asException());
-          }
-        }
+        closeWithError(Status.fromThrowable(t).asException());
       } finally {
         cancel();
       }


### PR DESCRIPTION
Synchronize access to `responseObserver` to prevent races:

```
java.lang.IllegalStateException: call already closed
    at com.google.common.base.Preconditions.checkState(Preconditions.java:507)
    at io.grpc.internal.ServerCallImpl.close(ServerCallImpl.java:172)
    at io.grpc.internal.ServerCallImpl.sendMessage(ServerCallImpl.java:142)
    at io.grpc.stub.ServerCalls$ServerCallStreamObserverImpl.onNext(ServerCalls.java:341)
    at io.envoyproxy.controlplane.server.DiscoveryRequestStreamObserver.send(DiscoveryRequestStreamObserver.java:133)
    at io.envoyproxy.controlplane.server.DiscoveryRequestStreamObserver.lambda$processRequest$3(DiscoveryRequestStreamObserver.java:109)
    at io.netty.util.concurrent.DefaultEventExecutor.run(DefaultEventExecutor.java:66)
    at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:909)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
    at java.base/java.lang.Thread.run(Thread.java:834)
```

Related to #106 