### PR TITLE
Owner e-mail change

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -9,5 +9,5 @@
 * Ben Hoyt ([b-hoyt](https://github.com/b-hoyt)) (bhoyt@salesforce.com)
 * Snow Pettersen ([snowp](https://github.com/snowp)) (snowp@squareup.com)
 * Dariusz Jędrzejczyk ([chemicL](https://github.com/chemicL)) (dariusz.jedrzejczyk@allegro.pl)
-* Jakub Dyszkiewicz ([jakubdyszkiewicz](https://github.com/jakubdyszkiewicz)) (jakub.dyszkiewicz@allegro.pl)
+* Jakub Dyszkiewicz ([jakubdyszkiewicz](https://github.com/jakubdyszkiewicz)) (jakub.dyszkiewicz@gmail.com)
 * Krzysztof Słonka ([slonka](https://github.com/slonka)) (krzysztof.slonka@allegro.pl)


### PR DESCRIPTION
I'm changing my e-mail to private one, because soon I'll be leaving Allegro.

If possible, I'd like to stay as a maintainer of the project. I will still continue to work on Envoy-based Service Mesh, though more on the Go side. Knowing better the go-control-plane, I might bring some ideas to the java-control-plane.