### PR TITLE
CircleCI: manual snapshot deployment from branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,12 @@ jobs:
               else
                 mvn -B -s .circleci/settings.xml deploy
               fi
+            elif [[ -n "${DEPLOY_BRANCH}" ]]; then
+              echo $GPG_KEY | base64 --decode > signing-key
+              gpg --passphrase $GPG_PASSPHRASE --import signing-key
+              shred signing-key
+
+              mvn -B -s .circleci/settings-snapshots.xml deploy
             fi
 
       - run: bash <(curl -s https://codecov.io/bash)

--- a/.circleci/settings-snapshots.xml
+++ b/.circleci/settings-snapshots.xml
@@ -1,0 +1,40 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+    <servers>
+        <server>
+            <id>sonatype-nexus-snapshots</id>
+            <username>${env.SONATYPE_USER}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
+        </server>
+    </servers>
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <repositories>
+                <repository>
+                    <id>sonatype-nexus-snapshots</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+        <profile>
+            <id>signing</id>
+            <properties>
+                <gpg.executable>gpg</gpg.executable>
+                <gpg.keyname>${env.GPG_KEY_NAME}</gpg.keyname>
+                <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+            </properties>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>ci</activeProfile>
+        <activeProfile>signing</activeProfile>
+    </activeProfiles>
+</settings>


### PR DESCRIPTION
Add ability to manually trigger publishing of snapshot artifacts from a branch.

Separate maven settings file is provided to prevent from publishing a release by mistake. 