### PR TITLE
Send EDS response in ADS mode when Envoy reconnect and asks with Empty version

### DIFF
--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/SimpleCacheTest.java
@@ -14,6 +14,7 @@ import io.envoyproxy.envoy.api.v2.auth.Secret;
 import io.envoyproxy.envoy.api.v2.core.Node;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -73,11 +74,48 @@ public class SimpleCacheTest {
             .setNode(Node.getDefaultInstance())
             .setTypeUrl(Resources.ENDPOINT_TYPE_URL)
             .addResourceNames("none")
+            .setVersionInfo("123")
             .build(),
         Collections.emptySet(),
         responseTracker);
 
     assertThatWatchIsOpenWithNoResponses(new WatchAndTracker(watch, responseTracker));
+  }
+
+  @Test
+  public void invalidNamesListShouldReturnWatcherWithResponseInAdsModeWhenVersionIsEmpty() {
+    SimpleCache<String> cache = new SimpleCache<>(new SingleNodeGroup());
+
+    cache.setSnapshot(SingleNodeGroup.GROUP, MULTIPLE_RESOURCES_SNAPSHOT2);
+
+    ResponseTracker responseTracker = new ResponseTracker();
+
+    Watch watch = cache.createWatch(
+        true,
+        DiscoveryRequest.newBuilder()
+            .setNode(Node.getDefaultInstance())
+            .setTypeUrl(Resources.ENDPOINT_TYPE_URL)
+            .addAllResourceNames(MULTIPLE_RESOURCES_SNAPSHOT2.resources(Resources.ENDPOINT_TYPE_URL).keySet())
+            .addResourceNames("none")
+            .setVersionInfo("")
+            .build(),
+        Collections.emptySet(),
+        responseTracker);
+
+    assertThat(responseTracker.responses).isNotEmpty();
+
+    Response response = responseTracker.responses.getFirst();
+
+    assertThat(response).isNotNull();
+    assertThat(response.version()).isEqualTo(MULTIPLE_RESOURCES_SNAPSHOT2.version(watch.request().getTypeUrl()));
+
+    List<ClusterLoadAssignment> expectedResponse = new LinkedList<>((List<ClusterLoadAssignment>)
+        MULTIPLE_RESOURCES_SNAPSHOT2.resources(watch.request().getTypeUrl()).values());
+    // Because versionInfo in request is empty we should send all requested resources to don't leave Envoy
+    // in warming state.
+    expectedResponse.add(ClusterLoadAssignment.newBuilder().setClusterName("none").build());
+
+    assertThat(response.resources().toArray(new Message[0])).containsExactlyElementsOf(expectedResponse);
   }
 
   @Test
@@ -402,7 +440,8 @@ public class SimpleCacheTest {
             .setTypeUrl("")
             .build(),
         Collections.emptySet(),
-        r -> { });
+        r -> {
+        });
 
     // clearSnapshot should fail and the snapshot should be left untouched
     assertThat(cache.clearSnapshot(SingleNodeGroup.GROUP)).isFalse();
@@ -428,7 +467,8 @@ public class SimpleCacheTest {
             .setTypeUrl("")
             .build(),
         Collections.emptySet(),
-        r -> { });
+        r -> {
+        });
 
     assertThat(cache.groups()).containsExactly(SingleNodeGroup.GROUP);
   }


### PR DESCRIPTION
We found that Envoy has a cluster in warming state after reconnect to new control-plane.
So let's assume Envoy is connected to `Control-plane1`. `Control-plane1` receive information about the new cluster`[Cluster1]` and send CDS response to Envoy using ADS. `Control-plane1` die and at the same time cluster`[Cluster1]` has been removed. Envoy connects to Control-plane2 and send[EDS,LDS,RDS] requests. Because Envoy didn't received response EDS from `Control-plane1` this cluster is in warming state. EDS request from Envoy to `Control-plane2`contains resource name of removed cluster`[Cluster1]` and `Control-plane2` doesn't know about the cluster which was sent by `Control-plane1` to Envoy. Because ADS implementation requires to send only response when all requested resources in snapshot `Control-plane2` won’t respond. In this situation Envoy stay in warming phase for ever.