### PR TITLE
Don't store whole response

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java-control-plane</artifactId>
         <groupId>io.envoyproxy.controlplane</groupId>
-        <version>0.1.23-SNAPSHOT</version>
+        <version>0.1.23-test-memory-SNAPSHOT</version>
     </parent>
 
     <artifactId>api</artifactId>

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java-control-plane</artifactId>
         <groupId>io.envoyproxy.controlplane</groupId>
-        <version>0.1.23-SNAPSHOT</version>
+        <version>0.1.23-test-memory-SNAPSHOT</version>
     </parent>
 
     <artifactId>cache</artifactId>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>io.envoyproxy.controlplane</groupId>
             <artifactId>api</artifactId>
-            <version>0.1.23-SNAPSHOT</version>
+            <version>0.1.23-test-memory-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/ConfigWatcher.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/ConfigWatcher.java
@@ -26,4 +26,20 @@ public interface ConfigWatcher {
       DiscoveryRequest request,
       Set<String> knownResourceNames,
       Consumer<Response> responseConsumer);
+
+  /**
+   * Returns a new configuration resource {@link Watch} for the given discovery request.
+   *
+   * @param ads is the watch for an ADS request?
+   * @param request the discovery request (node, names, etc.) to use to generate the watch
+   * @param knownResourceNames resources that are already known to the caller
+   * @param responseConsumer the response handler, used to process outgoing response messages
+   * @param hasClusterChanged indicates if EDS should be send. Works in ads mode only.
+   */
+  Watch createWatch(
+      boolean ads,
+      DiscoveryRequest request,
+      Set<String> knownResourceNames,
+      Consumer<Response> responseConsumer,
+      boolean hasClusterChanged);
 }

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -81,6 +81,15 @@ public class SimpleCache<T> implements SnapshotCache<T> {
     }
   }
 
+  @Override
+  public Watch createWatch(
+      boolean ads,
+      DiscoveryRequest request,
+      Set<String> knownResourceNames,
+      Consumer<Response> responseConsumer) {
+    return createWatch(ads, request, knownResourceNames, responseConsumer, false);
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -89,7 +98,8 @@ public class SimpleCache<T> implements SnapshotCache<T> {
       boolean ads,
       DiscoveryRequest request,
       Set<String> knownResourceNames,
-      Consumer<Response> responseConsumer) {
+      Consumer<Response> responseConsumer,
+      boolean hasClusterChanged) {
 
     T group = groups.hash(request.getNode());
     // even though we're modifying, we take a readLock to allow multiple watches to be created in parallel since it
@@ -121,6 +131,10 @@ public class SimpleCache<T> implements SnapshotCache<T> {
 
             return watch;
           }
+        } else if (hasClusterChanged && request.getTypeUrl().equals(Resources.ENDPOINT_TYPE_URL)) {
+          respond(watch, snapshot, group);
+
+          return watch;
         }
       }
 

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/TestResources.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/TestResources.java
@@ -96,6 +96,17 @@ public class TestResources {
    * @param port port to use for the endpoint
    */
   public static ClusterLoadAssignment createEndpoint(String clusterName, int port) {
+    return createEndpoint(clusterName, LOCALHOST, port);
+  }
+
+  /**
+   * Returns a new test endpoint for the given cluster.
+   *
+   * @param clusterName name of the test cluster that is associated with this endpoint
+   * @param address ip address to use for the endpoint
+   * @param port port to use for the endpoint
+   */
+  public static ClusterLoadAssignment createEndpoint(String clusterName, String address, int port) {
     return ClusterLoadAssignment.newBuilder()
         .setClusterName(clusterName)
         .addEndpoints(LocalityLbEndpoints.newBuilder()
@@ -103,7 +114,7 @@ public class TestResources {
                 .setEndpoint(Endpoint.newBuilder()
                     .setAddress(Address.newBuilder()
                         .setSocketAddress(SocketAddress.newBuilder()
-                            .setAddress(LOCALHOST)
+                            .setAddress(address)
                             .setPortValue(port)
                             .setProtocol(Protocol.TCP))))))
         .build();

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.envoyproxy.controlplane</groupId>
     <artifactId>java-control-plane</artifactId>
-    <version>0.1.23-SNAPSHOT</version>
+    <version>0.1.23-test-memory-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java-control-plane</artifactId>
         <groupId>io.envoyproxy.controlplane</groupId>
-        <version>0.1.23-SNAPSHOT</version>
+        <version>0.1.23-test-memory-SNAPSHOT</version>
     </parent>
 
     <artifactId>server</artifactId>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>io.envoyproxy.controlplane</groupId>
             <artifactId>cache</artifactId>
-            <version>0.1.23-SNAPSHOT</version>
+            <version>0.1.23-test-memory-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
  */
 public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObserver {
   private final ConcurrentMap<String, Watch> watches;
-  private final ConcurrentMap<String, LatestResponse> latestResponse;
+  private final ConcurrentMap<String, LatestDiscoveryResponse> latestResponse;
   private final ConcurrentMap<String, Set<String>> ackedResources;
 
   AdsDiscoveryRequestStreamObserver(StreamObserver<DiscoveryResponse> responseObserver,
@@ -59,12 +59,12 @@ public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
   }
 
   @Override
-  LatestResponse latestResponse(String typeUrl) {
+  LatestDiscoveryResponse latestResponse(String typeUrl) {
     return latestResponse.get(typeUrl);
   }
 
   @Override
-  void setLatestResponse(String typeUrl, LatestResponse response) {
+  void setLatestResponse(String typeUrl, LatestDiscoveryResponse response) {
     latestResponse.put(typeUrl, response);
     if (typeUrl.equals(Resources.CLUSTER_TYPE_URL)) {
       hasClusterChanged.set(true);

--- a/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
  */
 public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObserver {
   private final ConcurrentMap<String, Watch> watches;
-  private final ConcurrentMap<String, DiscoveryResponse> latestResponse;
+  private final ConcurrentMap<String, LatestResponse> latestResponse;
   private final ConcurrentMap<String, Set<String>> ackedResources;
 
   AdsDiscoveryRequestStreamObserver(StreamObserver<DiscoveryResponse> responseObserver,
@@ -59,12 +59,12 @@ public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
   }
 
   @Override
-  DiscoveryResponse latestResponse(String typeUrl) {
+  LatestResponse latestResponse(String typeUrl) {
     return latestResponse.get(typeUrl);
   }
 
   @Override
-  void setLatestResponse(String typeUrl, DiscoveryResponse response) {
+  void setLatestResponse(String typeUrl, LatestResponse response) {
     latestResponse.put(typeUrl, response);
     if (typeUrl.equals(Resources.CLUSTER_TYPE_URL)) {
       hasClusterChanged.set(true);

--- a/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
@@ -66,6 +66,11 @@ public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
   @Override
   void setLatestResponse(String typeUrl, DiscoveryResponse response) {
     latestResponse.put(typeUrl, response);
+    if (typeUrl.equals(Resources.CLUSTER_TYPE_URL)) {
+      hasClusterChanged.set(true);
+    } else if (typeUrl.equals(Resources.ENDPOINT_TYPE_URL)) {
+      hasClusterChanged.set(false);
+    }
   }
 
   @Override

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -74,12 +74,12 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
       return;
     }
 
-    LatestResponse latestResponse = latestResponse(requestTypeUrl);
-    String resourceNonce = latestResponse == null ? null : latestResponse.getNonce();
+    LatestDiscoveryResponse latestDiscoveryResponse = latestResponse(requestTypeUrl);
+    String resourceNonce = latestDiscoveryResponse == null ? null : latestDiscoveryResponse.getNonce();
 
     if (isNullOrEmpty(resourceNonce) || resourceNonce.equals(nonce)) {
-      if (!request.hasErrorDetail() && latestResponse != null) {
-        setAckedResources(requestTypeUrl, latestResponse.getResources());
+      if (!request.hasErrorDetail() && latestDiscoveryResponse != null) {
+        setAckedResources(requestTypeUrl, latestDiscoveryResponse.getResources());
       }
 
       computeWatch(requestTypeUrl, () -> discoverySever.configWatcher.createWatch(
@@ -158,7 +158,10 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
     // which may see the incoming request arrive before the map is updated, failing the nonce check erroneously.
     setLatestResponse(
         typeUrl,
-        new LatestResponse(nonce, resources.stream().map(Resources::getResourceName).collect(Collectors.toSet()))
+        new LatestDiscoveryResponse(
+            nonce,
+            resources.stream().map(Resources::getResourceName).collect(Collectors.toSet())
+        )
     );
     synchronized (responseObserver) {
       if (!isClosing) {
@@ -177,9 +180,9 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
 
   abstract boolean ads();
 
-  abstract LatestResponse latestResponse(String typeUrl);
+  abstract LatestDiscoveryResponse latestResponse(String typeUrl);
 
-  abstract void setLatestResponse(String typeUrl, LatestResponse response);
+  abstract void setLatestResponse(String typeUrl, LatestDiscoveryResponse response);
 
   abstract Set<String> ackedResources(String typeUrl);
 

--- a/server/src/main/java/io/envoyproxy/controlplane/server/LatestDiscoveryResponse.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/LatestDiscoveryResponse.java
@@ -3,12 +3,12 @@ package io.envoyproxy.controlplane.server;
 import java.util.Objects;
 import java.util.Set;
 
-class LatestResponse {
+class LatestDiscoveryResponse {
 
   private final String nonce;
   private final Set<String> resources;
 
-  public LatestResponse(String nonce, Set<String> resources) {
+  public LatestDiscoveryResponse(String nonce, Set<String> resources) {
     this.nonce = nonce;
     this.resources = resources;
   }
@@ -29,7 +29,7 @@ class LatestResponse {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    LatestResponse that = (LatestResponse) o;
+    LatestDiscoveryResponse that = (LatestDiscoveryResponse) o;
     return Objects.equals(nonce, that.nonce)
         && Objects.equals(resources, that.resources);
   }

--- a/server/src/main/java/io/envoyproxy/controlplane/server/LatestResponse.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/LatestResponse.java
@@ -23,11 +23,15 @@ class LatestResponse {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     LatestResponse that = (LatestResponse) o;
-    return Objects.equals(nonce, that.nonce) &&
-        Objects.equals(resources, that.resources);
+    return Objects.equals(nonce, that.nonce)
+        && Objects.equals(resources, that.resources);
   }
 
   @Override
@@ -37,9 +41,9 @@ class LatestResponse {
 
   @Override
   public String toString() {
-    return "LatestResponse{" +
-        "nonce='" + nonce + '\'' +
-        ", resources=" + resources +
-        '}';
+    return "LatestResponse{"
+        + "nonce='" + nonce + '\''
+        + ", resources=" + resources
+        + '}';
   }
 }

--- a/server/src/main/java/io/envoyproxy/controlplane/server/LatestResponse.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/LatestResponse.java
@@ -1,0 +1,45 @@
+package io.envoyproxy.controlplane.server;
+
+import java.util.Objects;
+import java.util.Set;
+
+class LatestResponse {
+
+  private final String nonce;
+  private final Set<String> resources;
+
+  public LatestResponse(String nonce, Set<String> resources) {
+    this.nonce = nonce;
+    this.resources = resources;
+  }
+
+  public String getNonce() {
+    return nonce;
+  }
+
+  public Set<String> getResources() {
+    return resources;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LatestResponse that = (LatestResponse) o;
+    return Objects.equals(nonce, that.nonce) &&
+        Objects.equals(resources, that.resources);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nonce, resources);
+  }
+
+  @Override
+  public String toString() {
+    return "LatestResponse{" +
+        "nonce='" + nonce + '\'' +
+        ", resources=" + resources +
+        '}';
+  }
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
@@ -14,7 +14,7 @@ import java.util.function.Supplier;
  */
 public class XdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObserver {
   private volatile Watch watch;
-  private volatile DiscoveryResponse latestResponse;
+  private volatile LatestResponse latestResponse;
   // ackedResources is only used in the same thread so it need not be volatile
   private Set<String> ackedResources;
 
@@ -40,12 +40,12 @@ public class XdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
   }
 
   @Override
-  DiscoveryResponse latestResponse(String typeUrl) {
+  LatestResponse latestResponse(String typeUrl) {
     return latestResponse;
   }
 
   @Override
-  void setLatestResponse(String typeUrl, DiscoveryResponse response) {
+  void setLatestResponse(String typeUrl, LatestResponse response) {
     latestResponse = response;
   }
 

--- a/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
@@ -14,7 +14,7 @@ import java.util.function.Supplier;
  */
 public class XdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObserver {
   private volatile Watch watch;
-  private volatile LatestResponse latestResponse;
+  private volatile LatestDiscoveryResponse latestDiscoveryResponse;
   // ackedResources is only used in the same thread so it need not be volatile
   private Set<String> ackedResources;
 
@@ -40,13 +40,13 @@ public class XdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
   }
 
   @Override
-  LatestResponse latestResponse(String typeUrl) {
-    return latestResponse;
+  LatestDiscoveryResponse latestResponse(String typeUrl) {
+    return latestDiscoveryResponse;
   }
 
   @Override
-  void setLatestResponse(String typeUrl, LatestResponse response) {
-    latestResponse = response;
+  void setLatestResponse(String typeUrl, LatestDiscoveryResponse response) {
+    latestDiscoveryResponse = response;
   }
 
   @Override

--- a/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerAdsIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerAdsIT.java
@@ -52,7 +52,15 @@ public class DiscoveryServerAdsIT {
 
       cache.setSnapshot(
           GROUP,
-          createSnapshot(true, "upstream", "upstream", EchoContainer.PORT, "listener0", LISTENER_PORT, "route0", "1"));
+          createSnapshot(true,
+              "upstream",
+              UPSTREAM.ipAddress(),
+              EchoContainer.PORT,
+              "listener0",
+              LISTENER_PORT,
+              "route0",
+              "1")
+      );
 
       DiscoveryServer server = new DiscoveryServer(callbacks, cache);
 

--- a/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerAdsWarmingClusterIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerAdsWarmingClusterIT.java
@@ -1,0 +1,492 @@
+package io.envoyproxy.controlplane.server;
+
+import static io.envoyproxy.controlplane.server.TestSnapshots.createSnapshot;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.protobuf.Message;
+import com.google.protobuf.util.Durations;
+import io.envoyproxy.controlplane.cache.CacheStatusInfo;
+import io.envoyproxy.controlplane.cache.NodeGroup;
+import io.envoyproxy.controlplane.cache.Resources;
+import io.envoyproxy.controlplane.cache.Response;
+import io.envoyproxy.controlplane.cache.Snapshot;
+import io.envoyproxy.controlplane.cache.SnapshotCache;
+import io.envoyproxy.controlplane.cache.StatusInfo;
+import io.envoyproxy.controlplane.cache.TestResources;
+import io.envoyproxy.controlplane.cache.Watch;
+import io.envoyproxy.controlplane.cache.WatchCancelledException;
+import io.envoyproxy.envoy.api.v2.Cluster;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
+import io.envoyproxy.envoy.api.v2.DiscoveryRequest;
+import io.envoyproxy.envoy.api.v2.DiscoveryResponse;
+import io.envoyproxy.envoy.api.v2.Listener;
+import io.envoyproxy.envoy.api.v2.RouteConfiguration;
+import io.envoyproxy.envoy.api.v2.core.AggregatedConfigSource;
+import io.envoyproxy.envoy.api.v2.core.ConfigSource;
+import io.envoyproxy.envoy.api.v2.core.Http2ProtocolOptions;
+import io.grpc.netty.NettyServerBuilder;
+import io.restassured.http.ContentType;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import javax.annotation.concurrent.GuardedBy;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+import org.testcontainers.shaded.org.apache.commons.lang.math.RandomUtils;
+
+public class DiscoveryServerAdsWarmingClusterIT {
+
+  private static final String CONFIG = "envoy/ads.config.yaml";
+  private static final String GROUP = "key";
+  private static final Integer LISTENER_PORT = 10000;
+  private static final SimpleCache<String> cache = new SimpleCache<>(node -> GROUP);
+
+  private static final CountDownLatch onStreamOpenLatch = new CountDownLatch(1);
+  private static final CountDownLatch onStreamRequestLatch = new CountDownLatch(1);
+  private static final CountDownLatch onStreamResponseLatch = new CountDownLatch(1);
+
+  private static final NettyGrpcServerRule ADS = new NettyGrpcServerRule() {
+    @Override
+    protected void configureServerBuilder(NettyServerBuilder builder) {
+      ExecutorService executorService = Executors.newSingleThreadExecutor();
+      final DiscoveryServerCallbacks callbacks = new DiscoveryServerCallbacks() {
+        @Override
+        public void onStreamOpen(long streamId, String typeUrl) {
+          onStreamOpenLatch.countDown();
+        }
+
+        @Override
+        public void onStreamRequest(long streamId, DiscoveryRequest request) {
+          onStreamRequestLatch.countDown();
+        }
+
+        @Override
+        public void onStreamResponse(long streamId, DiscoveryRequest request, DiscoveryResponse response) {
+          if (request.getTypeUrl().equals(Resources.CLUSTER_TYPE_URL)) {
+            executorService.submit(() -> cache.setSnapshot(
+                GROUP,
+                createSnapshot(true,
+                    "upstream",
+                    UPSTREAM.ipAddress(),
+                    EchoContainer.PORT,
+                    "listener0",
+                    LISTENER_PORT,
+                    "route0",
+                    "2"))
+            );
+          }
+          onStreamResponseLatch.countDown();
+        }
+      };
+
+      cache.setSnapshot(
+          GROUP,
+          createSnapshotWithNotWorkingCluster(true,
+              "upstream",
+              UPSTREAM.ipAddress(),
+              EchoContainer.PORT,
+              "listener0",
+              LISTENER_PORT,
+              "route0"));
+
+      DiscoveryServer server = new DiscoveryServer(callbacks, cache);
+
+      builder.addService(server.getAggregatedDiscoveryServiceImpl());
+    }
+  };
+
+  private static final Network NETWORK = Network.newNetwork();
+
+  private static final EnvoyContainer ENVOY = new EnvoyContainer(CONFIG, () -> ADS.getServer().getPort())
+      .withExposedPorts(LISTENER_PORT)
+      .withNetwork(NETWORK);
+
+  private static final EchoContainer UPSTREAM = new EchoContainer()
+      .withNetwork(NETWORK)
+      .withNetworkAliases("upstream");
+
+  @ClassRule
+  public static final RuleChain RULES = RuleChain.outerRule(UPSTREAM)
+      .around(ADS)
+      .around(ENVOY);
+
+  @Test
+  public void validateTestRequestToEchoServerViaEnvoy() throws InterruptedException {
+    assertThat(onStreamOpenLatch.await(15, TimeUnit.SECONDS)).isTrue()
+        .overridingErrorMessage("failed to open ADS stream");
+
+    assertThat(onStreamRequestLatch.await(15, TimeUnit.SECONDS)).isTrue()
+        .overridingErrorMessage("failed to receive ADS request");
+
+    assertThat(onStreamResponseLatch.await(15, TimeUnit.SECONDS)).isTrue()
+        .overridingErrorMessage("failed to send ADS response");
+
+    String baseUri = String.format("http://%s:%d", ENVOY.getContainerIpAddress(), ENVOY.getMappedPort(LISTENER_PORT));
+
+    await().atMost(5, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
+        () -> given().baseUri(baseUri).contentType(ContentType.TEXT)
+            .when().get("/")
+            .then().statusCode(200)
+            .and().body(containsString(UPSTREAM.response)));
+  }
+
+  static Snapshot createSnapshotWithNotWorkingCluster(
+      boolean ads,
+      String clusterName,
+      String endpointAddress,
+      int endpointPort,
+      String listenerName,
+      int listenerPort,
+      String routeName) {
+
+    ConfigSource edsSource = ConfigSource.newBuilder()
+        .setAds(AggregatedConfigSource.getDefaultInstance())
+        .build();
+
+    Cluster cluster = Cluster.newBuilder()
+        .setName(clusterName)
+        .setConnectTimeout(Durations.fromSeconds(RandomUtils.nextInt(5)))
+        // we are enabling HTTP2 - communication with cluster won't work
+        .setHttp2ProtocolOptions(Http2ProtocolOptions.newBuilder().build())
+        .setEdsClusterConfig(Cluster.EdsClusterConfig.newBuilder()
+            .setEdsConfig(edsSource)
+            .setServiceName(clusterName))
+        .setType(Cluster.DiscoveryType.EDS)
+        .build();
+    ClusterLoadAssignment endpoint = TestResources.createEndpoint(clusterName, endpointAddress, endpointPort);
+    Listener listener = TestResources.createListener(ads, listenerName, listenerPort, routeName);
+    RouteConfiguration route = TestResources.createRoute(routeName, clusterName);
+
+    // here we have new version of resources other than CDS.
+    return Snapshot.create(
+        ImmutableList.of(cluster),
+        "1",
+        ImmutableList.of(endpoint),
+        "2",
+        ImmutableList.of(listener),
+        "2",
+        ImmutableList.of(route),
+        "2",
+        ImmutableList.of(),
+        "2");
+  }
+
+
+  /**
+   * Code has been copied from io.envoyproxy.controlplane.cache.SimpleCache to show specific case when
+   * Envoy might stuck with warming cluster. Class has removed lines from method setSnapshot which are responsible for
+   * responding for watches. Because to reproduce this problem we need a lot of connected Envoy's and changes to
+   * snapshot it is easier to reproduce this way.
+   */
+  static class SimpleCache<T> implements SnapshotCache<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(io.envoyproxy.controlplane.cache.SimpleCache.class);
+
+    private final NodeGroup<T> groups;
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final Lock readLock = lock.readLock();
+    private final Lock writeLock = lock.writeLock();
+
+    @GuardedBy("lock")
+    private final Map<T, Snapshot> snapshots = new HashMap<>();
+    private final ConcurrentMap<T, CacheStatusInfo<T>> statuses = new ConcurrentHashMap<>();
+
+    private AtomicLong watchCount = new AtomicLong();
+
+    /**
+     * Constructs a simple cache.
+     *
+     * @param groups maps an envoy host to a node group
+     */
+    public SimpleCache(NodeGroup<T> groups) {
+      this.groups = groups;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean clearSnapshot(T group) {
+      // we take a writeLock to prevent watches from being created
+      writeLock.lock();
+      try {
+        CacheStatusInfo<T> status = statuses.get(group);
+
+        // If we don't know about this group, do nothing.
+        if (status != null && status.numWatches() > 0) {
+          LOGGER.warn("tried to clear snapshot for group with existing watches, group={}", group);
+
+          return false;
+        }
+
+        statuses.remove(group);
+        snapshots.remove(group);
+
+        return true;
+      } finally {
+        writeLock.unlock();
+      }
+    }
+
+    @Override
+    public Watch createWatch(
+        boolean ads,
+        DiscoveryRequest request,
+        Set<String> knownResourceNames,
+        Consumer<Response> responseConsumer) {
+      return createWatch(ads, request, knownResourceNames, responseConsumer, false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Watch createWatch(
+        boolean ads,
+        DiscoveryRequest request,
+        Set<String> knownResourceNames,
+        Consumer<Response> responseConsumer,
+        boolean hasClusterChanged) {
+
+      T group = groups.hash(request.getNode());
+      // even though we're modifying, we take a readLock to allow multiple watches to be created in parallel since it
+      // doesn't conflict
+      readLock.lock();
+      try {
+        CacheStatusInfo<T> status = statuses.computeIfAbsent(group, g -> new CacheStatusInfo<>(group));
+        status.setLastWatchRequestTime(System.currentTimeMillis());
+
+        Snapshot snapshot = snapshots.get(group);
+        String version = snapshot == null ? "" : snapshot.version(request.getTypeUrl(), request.getResourceNamesList());
+
+        Watch watch = new Watch(ads, request, responseConsumer);
+
+        if (snapshot != null) {
+          Set<String> requestedResources = ImmutableSet.copyOf(request.getResourceNamesList());
+
+          // If the request is asking for resources we haven't sent to the proxy yet,
+          //see if we have additional resources.
+          if (!knownResourceNames.equals(requestedResources)) {
+            Sets.SetView<String> newResourceHints = Sets.difference(requestedResources, knownResourceNames);
+
+            // If any of the newly requested resources are in the snapshot respond immediately.
+            //If not we'll fall back to version comparisons.
+            if (snapshot.resources(request.getTypeUrl())
+                .keySet()
+                .stream()
+                .anyMatch(newResourceHints::contains)) {
+              respond(watch, snapshot, group);
+
+              return watch;
+            }
+          } else if (hasClusterChanged && request.getTypeUrl().equals(Resources.ENDPOINT_TYPE_URL)) {
+            respond(watch, snapshot, group);
+
+            return watch;
+          }
+        }
+
+        // If the requested version is up-to-date or missing a response, leave an open watch.
+        if (snapshot == null || request.getVersionInfo().equals(version)) {
+          long watchId = watchCount.incrementAndGet();
+
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("open watch {} for {}[{}] from node {} for version {}",
+                watchId,
+                request.getTypeUrl(),
+                String.join(", ", request.getResourceNamesList()),
+                group,
+                request.getVersionInfo());
+          }
+
+          status.setWatch(watchId, watch);
+
+          watch.setStop(() -> status.removeWatch(watchId));
+
+          return watch;
+        }
+
+        // Otherwise, the watch may be responded immediately
+        boolean responded = respond(watch, snapshot, group);
+
+        if (!responded) {
+          long watchId = watchCount.incrementAndGet();
+
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("did not respond immediately, leaving open watch {} for {}[{}] from node {} for version {}",
+                watchId,
+                request.getTypeUrl(),
+                String.join(", ", request.getResourceNamesList()),
+                group,
+                request.getVersionInfo());
+          }
+
+          status.setWatch(watchId, watch);
+
+          watch.setStop(() -> status.removeWatch(watchId));
+        }
+
+        return watch;
+      } finally {
+        readLock.unlock();
+      }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Snapshot getSnapshot(T group) {
+      readLock.lock();
+
+      try {
+        return snapshots.get(group);
+      } finally {
+        readLock.unlock();
+      }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<T> groups() {
+      return ImmutableSet.copyOf(statuses.keySet());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized void setSnapshot(T group, Snapshot snapshot) {
+      // we take a writeLock to prevent watches from being created while we update the snapshot
+      CacheStatusInfo<T> status;
+      writeLock.lock();
+      try {
+        // Update the existing snapshot entry.
+        snapshots.put(group, snapshot);
+        status = statuses.get(group);
+      } finally {
+        writeLock.unlock();
+      }
+
+      if (status == null) {
+        return;
+      }
+      // This code has been removed to show specific case which is hard to reproduce in integration test:
+      //      1. Envoy connects to control-plane
+      //      2. Snapshot already exists in control-plane <- other instance share same group
+      //      3. Control-plane respond with CDS in createWatch method
+      //      4. There is snapshot update which change CDS and EDS versions
+      //      5. Envoy sends EDS request
+      //      6. Control-plane respond with EDS in createWatch method
+      //      7. Envoy resume CDS and EDS requests.
+      //      8. Envoy sends request CDS
+      //      9. Control plane respond with CDS in createWatch method
+      //      10. Envoy sends EDS requests
+      //      11. Control plane doesn't respond because version hasn't changed
+      //      12. Cluster of service stays in warming phase
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public StatusInfo statusInfo(T group) {
+      readLock.lock();
+
+      try {
+        return statuses.get(group);
+      } finally {
+        readLock.unlock();
+      }
+    }
+
+    private Response createResponse(DiscoveryRequest request,
+                                    Map<String, ? extends Message> resources,
+                                    String version) {
+      Collection<? extends Message> filtered = request.getResourceNamesList().isEmpty()
+          ? resources.values()
+          : request.getResourceNamesList().stream()
+          .map(resources::get)
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
+
+      return Response.create(request, filtered, version);
+    }
+
+    private boolean respond(Watch watch, Snapshot snapshot, T group) {
+      Map<String, ? extends Message> snapshotResources = snapshot.resources(watch.request().getTypeUrl());
+
+      if (!watch.request().getResourceNamesList().isEmpty() && watch.ads()) {
+        Collection<String> missingNames = watch.request().getResourceNamesList().stream()
+            .filter(name -> !snapshotResources.containsKey(name))
+            .collect(Collectors.toList());
+
+        if (!missingNames.isEmpty()) {
+          LOGGER.info(
+              "not responding in ADS mode for {} from node {} at version {} for request [{}] since [{}] not in "
+                  + "snapshot",
+              watch.request().getTypeUrl(),
+              group,
+              snapshot.version(watch.request().getTypeUrl(), watch.request().getResourceNamesList()),
+              String.join(", ", watch.request().getResourceNamesList()),
+              String.join(", ", missingNames));
+
+          return false;
+        }
+      }
+
+      String version = snapshot.version(watch.request().getTypeUrl(), watch.request().getResourceNamesList());
+
+      LOGGER.info("responding for {} from node {} at version {} with version {}",
+          watch.request().getTypeUrl(),
+          group,
+          watch.request().getVersionInfo(),
+          version);
+
+      Response response = createResponse(
+          watch.request(),
+          snapshotResources,
+          version);
+
+      try {
+        watch.respond(response);
+        return true;
+      } catch (WatchCancelledException e) {
+        LOGGER.error(
+            "failed to respond for {} from node {} at version {} with version {} because watch was already cancelled",
+            watch.request().getTypeUrl(),
+            group,
+            watch.request().getVersionInfo(),
+            version);
+      }
+
+      return false;
+    }
+  }
+}

--- a/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerTest.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerTest.java
@@ -824,9 +824,9 @@ public class DiscoveryServerTest {
     MockConfigWatcher configWatcher = new MockConfigWatcher(false, createResponses()) {
       @Override
       public Watch createWatch(boolean ads, DiscoveryRequest request, Set<String> knownResources,
-                               Consumer<Response> responseConsumer) {
+                               Consumer<Response> responseConsumer, boolean hasClusterChanged) {
         watchCreated.countDown();
-        watch.set(super.createWatch(ads, request, knownResources, responseConsumer));
+        watch.set(super.createWatch(ads, request, knownResources, responseConsumer, false));
         return watch.get();
       }
     };
@@ -978,7 +978,8 @@ public class DiscoveryServerTest {
         boolean ads,
         DiscoveryRequest request,
         Set<String> knownResources,
-        Consumer<Response> responseConsumer) {
+        Consumer<Response> responseConsumer,
+        boolean hasClusterChanged) {
 
       counts.put(request.getTypeUrl(), counts.getOrDefault(request.getTypeUrl(), 0) + 1);
 
@@ -1014,6 +1015,14 @@ public class DiscoveryServerTest {
       }
 
       return watch;
+    }
+
+    @Override
+    public Watch createWatch(boolean ads,
+                             DiscoveryRequest request,
+                             Set<String> knownResourceNames,
+                             Consumer<Response> responseConsumer) {
+      return createWatch(ads, request, knownResourceNames, responseConsumer, false);
     }
   }
 

--- a/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerXdsIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerXdsIT.java
@@ -1,6 +1,6 @@
 package io.envoyproxy.controlplane.server;
 
-import static io.envoyproxy.controlplane.server.TestSnapshots.createSnapshot;
+import static io.envoyproxy.controlplane.server.TestSnapshots.createSnapshotNoEds;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -52,7 +52,15 @@ public class DiscoveryServerXdsIT {
 
       cache.setSnapshot(
           GROUP,
-          createSnapshot(false, "upstream", "upstream", EchoContainer.PORT, "listener0", LISTENER_PORT, "route0", "1"));
+          createSnapshotNoEds(false,
+              "upstream",
+              "upstream",
+              EchoContainer.PORT,
+              "listener0",
+              LISTENER_PORT,
+              "route0",
+              "1")
+      );
 
       DiscoveryServer server = new DiscoveryServer(callbacks, cache);
 

--- a/server/src/test/java/io/envoyproxy/controlplane/server/EchoContainer.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/EchoContainer.java
@@ -2,6 +2,7 @@ package io.envoyproxy.controlplane.server;
 
 import java.util.UUID;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 class EchoContainer extends GenericContainer<EchoContainer> {
@@ -23,5 +24,13 @@ class EchoContainer extends GenericContainer<EchoContainer> {
     withCommand(String.format("-text=%s", response));
 
     waitingFor(Wait.forHttp("/").forStatusCode(200));
+  }
+
+  public String ipAddress() {
+    return getContainerInfo()
+        .getNetworkSettings()
+        .getNetworks()
+        .get(((Network.NetworkImpl) getNetwork()).getName())
+        .getIpAddress();
   }
 }

--- a/server/src/test/java/io/envoyproxy/controlplane/server/TestSnapshots.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/TestSnapshots.java
@@ -3,6 +3,7 @@ package io.envoyproxy.controlplane.server;
 import io.envoyproxy.controlplane.cache.Snapshot;
 import io.envoyproxy.controlplane.cache.TestResources;
 import io.envoyproxy.envoy.api.v2.Cluster;
+import io.envoyproxy.envoy.api.v2.ClusterLoadAssignment;
 import io.envoyproxy.envoy.api.v2.Listener;
 import io.envoyproxy.envoy.api.v2.RouteConfiguration;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
@@ -10,6 +11,30 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 class TestSnapshots {
 
   static Snapshot createSnapshot(
+      boolean ads,
+      String clusterName,
+      String endpointAddress,
+      int endpointPort,
+      String listenerName,
+      int listenerPort,
+      String routeName,
+      String version) {
+
+    Cluster cluster = TestResources.createCluster(clusterName);
+    ClusterLoadAssignment endpoint = TestResources.createEndpoint(clusterName, endpointAddress, endpointPort);
+    Listener listener = TestResources.createListener(ads, listenerName, listenerPort, routeName);
+    RouteConfiguration route = TestResources.createRoute(routeName, clusterName);
+
+    return Snapshot.create(
+        ImmutableList.of(cluster),
+        ImmutableList.of(endpoint),
+        ImmutableList.of(listener),
+        ImmutableList.of(route),
+        ImmutableList.of(),
+        version);
+  }
+
+  static Snapshot createSnapshotNoEds(
       boolean ads,
       String clusterName,
       String endpointAddress,

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java-control-plane</artifactId>
         <groupId>io.envoyproxy.controlplane</groupId>
-        <version>0.1.23-SNAPSHOT</version>
+        <version>0.1.23-test-memory-SNAPSHOT</version>
     </parent>
 
     <artifactId>test</artifactId>
@@ -18,13 +18,13 @@
         <dependency>
             <groupId>io.envoyproxy.controlplane</groupId>
             <artifactId>cache</artifactId>
-            <version>0.1.23-SNAPSHOT</version>
+            <version>0.1.23-test-memory-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>io.envoyproxy.controlplane</groupId>
             <artifactId>server</artifactId>
-            <version>0.1.23-SNAPSHOT</version>
+            <version>0.1.23-test-memory-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Some of our services are watching changes of all services. Because of this `latestResponse` might be really heavy and put pressure on GC because of number of changes. In our case each `AdsDiscoveryRequestStreamObserver` weight around 20MB. Let's say we have 20 services connected to one instance of control plane. It gives 400MB allocated for each change.
<img width="799" alt="Zrzut ekranu 2020-03-5 o 19 04 54" src="https://user-images.githubusercontent.com/13002762/76302650-a6ce4400-62c0-11ea-8b38-c741b4f08585.png">

Because we don't use whole data from Response I've added change which story only used data in object: nonce and resourceNames. Thanks to this change our GC pressure droped: 
![gc](https://user-images.githubusercontent.com/13002762/76302974-383db600-62c1-11ea-9726-acd2446f0360.png)

