### PR TITLE
Dont save whole response just data needed during another request

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -18,6 +18,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>${auto-value.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
             <version>${grpc.version}</version>

--- a/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
  */
 public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObserver {
   private final ConcurrentMap<String, Watch> watches;
-  private final ConcurrentMap<String, DiscoveryResponse> latestResponse;
+  private final ConcurrentMap<String, LatestDiscoveryResponse> latestResponse;
   private final ConcurrentMap<String, Set<String>> ackedResources;
 
   AdsDiscoveryRequestStreamObserver(StreamObserver<DiscoveryResponse> responseObserver,
@@ -59,12 +59,12 @@ public class AdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
   }
 
   @Override
-  DiscoveryResponse latestResponse(String typeUrl) {
+  LatestDiscoveryResponse latestResponse(String typeUrl) {
     return latestResponse.get(typeUrl);
   }
 
   @Override
-  void setLatestResponse(String typeUrl, DiscoveryResponse response) {
+  void setLatestResponse(String typeUrl, LatestDiscoveryResponse response) {
     latestResponse.put(typeUrl, response);
   }
 

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -155,7 +155,7 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
         typeUrl,
         LatestDiscoveryResponse.create(
             nonce,
-            resources.stream().map(Resources::getResourceName).collect(Collectors.toSet())
+            response.resources().stream().map(Resources::getResourceName).collect(Collectors.toSet())
         )
     );
     synchronized (responseObserver) {

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -71,16 +71,12 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
       return;
     }
 
-    DiscoveryResponse latestResponse = latestResponse(requestTypeUrl);
-    String resourceNonce = latestResponse == null ? null : latestResponse.getNonce();
+    LatestDiscoveryResponse latestDiscoveryResponse = latestResponse(requestTypeUrl);
+    String resourceNonce = latestDiscoveryResponse == null ? null : latestDiscoveryResponse.getNonce();
 
     if (isNullOrEmpty(resourceNonce) || resourceNonce.equals(nonce)) {
-      if (!request.hasErrorDetail() && latestResponse != null) {
-        Set<String> ackedResourcesForType = latestResponse.getResourcesList()
-            .stream()
-            .map(Resources::getResourceName)
-            .collect(Collectors.toSet());
-        setAckedResources(requestTypeUrl, ackedResourcesForType);
+      if (!request.hasErrorDetail() && latestDiscoveryResponse != null) {
+        setAckedResources(requestTypeUrl, latestDiscoveryResponse.getResources());
       }
 
       computeWatch(requestTypeUrl, () -> discoverySever.configWatcher.createWatch(
@@ -155,7 +151,13 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
     // Store the latest response *before* we send the response. This ensures that by the time the request
     // is processed the map is guaranteed to be updated. Doing it afterwards leads to a race conditions
     // which may see the incoming request arrive before the map is updated, failing the nonce check erroneously.
-    setLatestResponse(typeUrl, discoveryResponse);
+    setLatestResponse(
+        typeUrl,
+        new LatestDiscoveryResponse(
+            nonce,
+            resources.stream().map(Resources::getResourceName).collect(Collectors.toSet())
+        )
+    );
     synchronized (responseObserver) {
       if (!isClosing) {
         try {
@@ -173,9 +175,9 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
 
   abstract boolean ads();
 
-  abstract DiscoveryResponse latestResponse(String typeUrl);
+  abstract LatestDiscoveryResponse latestResponse(String typeUrl);
 
-  abstract void setLatestResponse(String typeUrl, DiscoveryResponse response);
+  abstract void setLatestResponse(String typeUrl, LatestDiscoveryResponse response);
 
   abstract Set<String> ackedResources(String typeUrl);
 

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -72,11 +72,11 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
     }
 
     LatestDiscoveryResponse latestDiscoveryResponse = latestResponse(requestTypeUrl);
-    String resourceNonce = latestDiscoveryResponse == null ? null : latestDiscoveryResponse.getNonce();
+    String resourceNonce = latestDiscoveryResponse == null ? null : latestDiscoveryResponse.nonce();
 
     if (isNullOrEmpty(resourceNonce) || resourceNonce.equals(nonce)) {
       if (!request.hasErrorDetail() && latestDiscoveryResponse != null) {
-        setAckedResources(requestTypeUrl, latestDiscoveryResponse.getResources());
+        setAckedResources(requestTypeUrl, latestDiscoveryResponse.resourceNames());
       }
 
       computeWatch(requestTypeUrl, () -> discoverySever.configWatcher.createWatch(
@@ -153,7 +153,7 @@ public abstract class DiscoveryRequestStreamObserver implements StreamObserver<D
     // which may see the incoming request arrive before the map is updated, failing the nonce check erroneously.
     setLatestResponse(
         typeUrl,
-        new LatestDiscoveryResponse(
+        LatestDiscoveryResponse.create(
             nonce,
             resources.stream().map(Resources::getResourceName).collect(Collectors.toSet())
         )

--- a/server/src/main/java/io/envoyproxy/controlplane/server/LatestDiscoveryResponse.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/LatestDiscoveryResponse.java
@@ -1,0 +1,49 @@
+package io.envoyproxy.controlplane.server;
+
+import java.util.Objects;
+import java.util.Set;
+
+class LatestDiscoveryResponse {
+
+  private final String nonce;
+  private final Set<String> resources;
+
+  public LatestDiscoveryResponse(String nonce, Set<String> resources) {
+    this.nonce = nonce;
+    this.resources = resources;
+  }
+
+  public String getNonce() {
+    return nonce;
+  }
+
+  public Set<String> getResources() {
+    return resources;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    LatestDiscoveryResponse that = (LatestDiscoveryResponse) o;
+    return Objects.equals(nonce, that.nonce)
+        && Objects.equals(resources, that.resources);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nonce, resources);
+  }
+
+  @Override
+  public String toString() {
+    return "LatestResponse{"
+        + "nonce='" + nonce + '\''
+        + ", resources=" + resources
+        + '}';
+  }
+}

--- a/server/src/main/java/io/envoyproxy/controlplane/server/LatestDiscoveryResponse.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/LatestDiscoveryResponse.java
@@ -1,49 +1,18 @@
 package io.envoyproxy.controlplane.server;
 
-import java.util.Objects;
+import com.google.auto.value.AutoValue;
 import java.util.Set;
 
-class LatestDiscoveryResponse {
-
-  private final String nonce;
-  private final Set<String> resources;
-
-  public LatestDiscoveryResponse(String nonce, Set<String> resources) {
-    this.nonce = nonce;
-    this.resources = resources;
+/**
+ * Class introduces optimization which store only required data during next request.
+ */
+@AutoValue
+public abstract class LatestDiscoveryResponse {
+  static LatestDiscoveryResponse create(String nonce, Set<String> resourceNames) {
+    return new AutoValue_LatestDiscoveryResponse(nonce, resourceNames);
   }
 
-  public String getNonce() {
-    return nonce;
-  }
+  abstract String nonce();
 
-  public Set<String> getResources() {
-    return resources;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    LatestDiscoveryResponse that = (LatestDiscoveryResponse) o;
-    return Objects.equals(nonce, that.nonce)
-        && Objects.equals(resources, that.resources);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(nonce, resources);
-  }
-
-  @Override
-  public String toString() {
-    return "LatestResponse{"
-        + "nonce='" + nonce + '\''
-        + ", resources=" + resources
-        + '}';
-  }
+  abstract Set<String> resourceNames();
 }

--- a/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/XdsDiscoveryRequestStreamObserver.java
@@ -14,7 +14,7 @@ import java.util.function.Supplier;
  */
 public class XdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObserver {
   private volatile Watch watch;
-  private volatile DiscoveryResponse latestResponse;
+  private volatile LatestDiscoveryResponse latestDiscoveryResponse;
   // ackedResources is only used in the same thread so it need not be volatile
   private Set<String> ackedResources;
 
@@ -40,13 +40,13 @@ public class XdsDiscoveryRequestStreamObserver extends DiscoveryRequestStreamObs
   }
 
   @Override
-  DiscoveryResponse latestResponse(String typeUrl) {
-    return latestResponse;
+  LatestDiscoveryResponse latestResponse(String typeUrl) {
+    return latestDiscoveryResponse;
   }
 
   @Override
-  void setLatestResponse(String typeUrl, DiscoveryResponse response) {
-    latestResponse = response;
+  void setLatestResponse(String typeUrl, LatestDiscoveryResponse response) {
+    latestDiscoveryResponse = response;
   }
 
   @Override


### PR DESCRIPTION
Some of our services are watching changes of all services. Because of this `latestResponse` might be really heavy and put pressure on GC because of number of changes. In our case each `AdsDiscoveryRequestStreamObserver` weight around 20MB. Let's say we have 20 services connected to one instance of control plane. It gives 400MB allocated for each change.
<img width="799" alt="Zrzut ekranu 2020-03-5 o 19 04 54" src="https://user-images.githubusercontent.com/13002762/76302650-a6ce4400-62c0-11ea-8b38-c741b4f08585.png">

Because we don't use whole data from Response I've added change which story only used data in object: nonce and resourceNames. Thanks to this change our GC pressure dropped: 
![gc](https://user-images.githubusercontent.com/13002762/76302974-383db600-62c1-11ea-9726-acd2446f0360.png)

