### PR TITLE
Store cache status info in a map by type url

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/GroupCacheStatusInfo.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/GroupCacheStatusInfo.java
@@ -4,8 +4,7 @@ import java.util.Collection;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * {@code CacheStatusInfo} provides a default implementation of {@link StatusInfo} for use in {@link Cache}
- * implementations.
+ * {@code GroupCacheStatusInfo} provides an implementation of {@link StatusInfo} for a group of {@link CacheStatusInfo}.
  */
 @ThreadSafe
 class GroupCacheStatusInfo<T> implements StatusInfo<T> {

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/GroupCacheStatusInfo.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/GroupCacheStatusInfo.java
@@ -1,0 +1,41 @@
+package io.envoyproxy.controlplane.cache;
+
+import java.util.Collection;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * {@code CacheStatusInfo} provides a default implementation of {@link StatusInfo} for use in {@link Cache}
+ * implementations.
+ */
+@ThreadSafe
+class GroupCacheStatusInfo<T> implements StatusInfo<T> {
+  private final Collection<CacheStatusInfo<T>> statuses;
+
+  public GroupCacheStatusInfo(Collection<CacheStatusInfo<T>> statuses) {
+    this.statuses = statuses;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public long lastWatchRequestTime() {
+    return statuses.stream().mapToLong(CacheStatusInfo::lastWatchRequestTime).max().orElse(0);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public T nodeGroup() {
+    return statuses.stream().map(CacheStatusInfo::nodeGroup).findFirst().orElse(null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int numWatches() {
+    return statuses.stream().mapToInt(CacheStatusInfo::numWatches).sum();
+  }
+}

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/GroupCacheStatusInfo.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/GroupCacheStatusInfo.java
@@ -1,5 +1,6 @@
 package io.envoyproxy.controlplane.cache;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -11,7 +12,7 @@ class GroupCacheStatusInfo<T> implements StatusInfo<T> {
   private final Collection<CacheStatusInfo<T>> statuses;
 
   public GroupCacheStatusInfo(Collection<CacheStatusInfo<T>> statuses) {
-    this.statuses = statuses;
+    this.statuses = new ArrayList<>(statuses);
   }
 
   /**

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -244,7 +244,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
         return null;
       }
 
-      return new GroupCacheStatusInfo<T>(statusMap.values());
+      return new GroupCacheStatusInfo<>(statusMap.values());
     } finally {
       readLock.unlock();
     }

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -1,6 +1,7 @@
 package io.envoyproxy.controlplane.cache;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
@@ -43,7 +44,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
 
   @GuardedBy("lock")
   private final Map<T, Snapshot> snapshots = new HashMap<>();
-  private final ConcurrentMap<T, CacheStatusInfo<T>> statuses = new ConcurrentHashMap<>();
+  private final ConcurrentMap<T, ConcurrentMap<String, CacheStatusInfo<T>>> statuses = new ConcurrentHashMap<>();
 
   private AtomicLong watchCount = new AtomicLong();
 
@@ -64,10 +65,10 @@ public class SimpleCache<T> implements SnapshotCache<T> {
     // we take a writeLock to prevent watches from being created
     writeLock.lock();
     try {
-      CacheStatusInfo<T> status = statuses.get(group);
+      Map<String, CacheStatusInfo<T>> status = statuses.get(group);
 
       // If we don't know about this group, do nothing.
-      if (status != null && status.numWatches() > 0) {
+      if (status != null && status.values().stream().mapToLong(CacheStatusInfo::numWatches).sum() > 0) {
         LOGGER.warn("tried to clear snapshot for group with existing watches, group={}", group);
 
         return false;
@@ -106,7 +107,8 @@ public class SimpleCache<T> implements SnapshotCache<T> {
     // doesn't conflict
     readLock.lock();
     try {
-      CacheStatusInfo<T> status = statuses.computeIfAbsent(group, g -> new CacheStatusInfo<>(group));
+      CacheStatusInfo<T> status = statuses.computeIfAbsent(group, g -> new ConcurrentHashMap<>())
+          .computeIfAbsent(request.getTypeUrl(), s -> new CacheStatusInfo<>(group));
       status.setLastWatchRequestTime(System.currentTimeMillis());
 
       Snapshot snapshot = snapshots.get(group);
@@ -212,7 +214,7 @@ public class SimpleCache<T> implements SnapshotCache<T> {
   @Override
   public synchronized void setSnapshot(T group, Snapshot snapshot) {
     // we take a writeLock to prevent watches from being created while we update the snapshot
-    CacheStatusInfo<T> status;
+    ConcurrentMap<String, CacheStatusInfo<T>> status;
     writeLock.lock();
     try {
       // Update the existing snapshot entry.
@@ -238,15 +240,25 @@ public class SimpleCache<T> implements SnapshotCache<T> {
     readLock.lock();
 
     try {
-      return statuses.get(group);
+      ConcurrentMap<String, CacheStatusInfo<T>> statusMap = statuses.get(group);
+      if (statusMap == null || statusMap.isEmpty()) {
+        return null;
+      }
+
+      return new GroupCacheStatusInfo<T>(statusMap.values());
     } finally {
       readLock.unlock();
     }
   }
 
   @VisibleForTesting
-  protected void respondWithSpecificOrder(T group, Snapshot snapshot, CacheStatusInfo<T> status) {
+  protected void respondWithSpecificOrder(T group, Snapshot snapshot, ConcurrentMap<String, CacheStatusInfo<T>> statusMap) {
     for (String typeUrl : Resources.TYPE_URLS) {
+      CacheStatusInfo<T> status = statusMap.get(typeUrl);
+      if (status == null) {
+        continue;
+      }
+
       status.watchesRemoveIf((id, watch) -> {
         if (!watch.request().getTypeUrl().equals(typeUrl)) {
           return false;
@@ -331,5 +343,13 @@ public class SimpleCache<T> implements SnapshotCache<T> {
     }
 
     return false;
+  }
+
+  private Map<String, CacheStatusInfo<T>> makeStatusMap(T group) {
+    ImmutableMap.Builder<String, CacheStatusInfo<T>> builder = ImmutableMap.builder();
+    Resources.TYPE_URLS.forEach(s -> {
+      builder.put(s, new CacheStatusInfo<>(group));
+    });
+    return builder.build();
   }
 }

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -1,7 +1,6 @@
 package io.envoyproxy.controlplane.cache;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
@@ -343,13 +342,5 @@ public class SimpleCache<T> implements SnapshotCache<T> {
     }
 
     return false;
-  }
-
-  private Map<String, CacheStatusInfo<T>> makeStatusMap(T group) {
-    ImmutableMap.Builder<String, CacheStatusInfo<T>> builder = ImmutableMap.builder();
-    Resources.TYPE_URLS.forEach(s -> {
-      builder.put(s, new CacheStatusInfo<>(group));
-    });
-    return builder.build();
   }
 }

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -251,7 +251,8 @@ public class SimpleCache<T> implements SnapshotCache<T> {
   }
 
   @VisibleForTesting
-  protected void respondWithSpecificOrder(T group, Snapshot snapshot, ConcurrentMap<String, CacheStatusInfo<T>> statusMap) {
+  protected void respondWithSpecificOrder(T group, Snapshot snapshot,
+                                          ConcurrentMap<String, CacheStatusInfo<T>> statusMap) {
     for (String typeUrl : Resources.TYPE_URLS) {
       CacheStatusInfo<T> status = statusMap.get(typeUrl);
       if (status == null) {

--- a/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerAdsWarmingClusterIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerAdsWarmingClusterIT.java
@@ -193,7 +193,8 @@ public class DiscoveryServerAdsWarmingClusterIT {
     }
 
     @Override
-    protected void respondWithSpecificOrder(T group, Snapshot snapshot, ConcurrentMap<String, CacheStatusInfo<T>> status) {
+    protected void respondWithSpecificOrder(T group, Snapshot snapshot,
+                                            ConcurrentMap<String, CacheStatusInfo<T>> status) {
       // This code has been removed to show specific case which is hard to reproduce in integration test:
       //      1. Envoy connects to control-plane
       //      2. Snapshot already exists in control-plane <- other instance share same group

--- a/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerAdsWarmingClusterIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/DiscoveryServerAdsWarmingClusterIT.java
@@ -24,6 +24,7 @@ import io.envoyproxy.envoy.api.v2.core.ConfigSource;
 import io.envoyproxy.envoy.api.v2.core.Http2ProtocolOptions;
 import io.grpc.netty.NettyServerBuilder;
 import io.restassured.http.ContentType;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -192,7 +193,7 @@ public class DiscoveryServerAdsWarmingClusterIT {
     }
 
     @Override
-    protected void respondWithSpecificOrder(T group, Snapshot snapshot, CacheStatusInfo<T> status) {
+    protected void respondWithSpecificOrder(T group, Snapshot snapshot, ConcurrentMap<String, CacheStatusInfo<T>> status) {
       // This code has been removed to show specific case which is hard to reproduce in integration test:
       //      1. Envoy connects to control-plane
       //      2. Snapshot already exists in control-plane <- other instance share same group

--- a/server/src/test/java/io/envoyproxy/controlplane/server/EnvoyContainer.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/EnvoyContainer.java
@@ -24,7 +24,7 @@ class EnvoyContainer extends GenericContainer<EnvoyContainer> {
   private final Supplier<Integer> controlPlanePortSupplier;
 
   EnvoyContainer(String config, Supplier<Integer> controlPlanePortSupplier) {
-    super("envoyproxy/envoy-alpine:latest");
+    super("envoyproxy/envoy-alpine-dev:latest");
 
     this.config = config;
     this.controlPlanePortSupplier = controlPlanePortSupplier;


### PR DESCRIPTION
Since PR #128 was merged we noticed a considerable increase in the time it takes for our control plane to do a `setSnapshot` operation, we have 1.5M watches per control plane machine, and that change makes the control plane have to iterate over those 1.5M watches up to 5 times.

The change is pretty straight forward and should have no issues, the only thing that's weird is that `SnapshotCache` provides a method for getting a `StatusInfo` and now we have a map, I found two solutions for this, either we break API compatibility and make `statusInfo(T group)` receive the desired typeUrl or we provide a wrapper `StatusInfo` clas which wrapps a collection of `CacheStatusInfo` and exposes the same API. I took the latter.