### PR TITLE
Fix flapping warming cluster integration tests

### DIFF
--- a/server/src/test/java/io/envoyproxy/controlplane/server/V2DiscoveryServerAdsWarmingClusterIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/V2DiscoveryServerAdsWarmingClusterIT.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.containsString;
 
 import com.google.protobuf.util.Durations;
 import io.envoyproxy.controlplane.cache.NodeGroup;
-import io.envoyproxy.controlplane.cache.Resources;
 import io.envoyproxy.controlplane.cache.TestResources;
 import io.envoyproxy.controlplane.cache.v2.SimpleCache;
 import io.envoyproxy.controlplane.cache.v2.Snapshot;
@@ -25,8 +24,6 @@ import io.envoyproxy.envoy.api.v2.core.Node;
 import io.grpc.netty.NettyServerBuilder;
 import io.restassured.http.ContentType;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -40,7 +37,7 @@ public class V2DiscoveryServerAdsWarmingClusterIT {
   private static final String CONFIG = "envoy/ads.v2.config.yaml";
   private static final String GROUP = "key";
   private static final Integer LISTENER_PORT = 10000;
-  private static final CustomCache<String> cache = new CustomCache<>(new NodeGroup<String>() {
+  private static final SimpleCache<String> cache = new SimpleCache<>(new NodeGroup<String>() {
     @Override public String hash(Node node) {
       return GROUP;
     }
@@ -57,7 +54,6 @@ public class V2DiscoveryServerAdsWarmingClusterIT {
   private static final NettyGrpcServerRule ADS = new NettyGrpcServerRule() {
     @Override
     protected void configureServerBuilder(NettyServerBuilder builder) {
-      ExecutorService executorService = Executors.newSingleThreadExecutor();
       final DiscoveryServerCallbacks callbacks = new DiscoveryServerCallbacks() {
             @Override
             public void onStreamOpen(long streamId, String typeUrl) {
@@ -79,7 +75,6 @@ public class V2DiscoveryServerAdsWarmingClusterIT {
             public void onStreamResponse(long streamId, DiscoveryRequest request, DiscoveryResponse response) {
               // Here we update a Snapshot with working cluster, but we change only CDS version, not EDS version.
               // This change allows to test if EDS will be sent anyway after CDS was sent.
-              createSnapshotWithWorkingClusterWithTheSameEdsVersion(request, executorService);
               onStreamResponseLatch.countDown();
             }
           };
@@ -131,33 +126,29 @@ public class V2DiscoveryServerAdsWarmingClusterIT {
     await().atMost(5, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
         () -> given().baseUri(baseUri).contentType(ContentType.TEXT)
             .when().get("/")
+            .then().statusCode(503));
+
+    // Here we update a Snapshot with working cluster, but we change only CDS version, not EDS version.
+    // This change allows to test if EDS will be sent anyway after CDS was sent.
+    createSnapshotWithWorkingClusterWithTheSameEdsVersion();
+
+    await().atMost(5, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
+        () -> given().baseUri(baseUri).contentType(ContentType.TEXT)
+            .when().get("/")
             .then().statusCode(200)
             .and().body(containsString(UPSTREAM.response)));
   }
 
-  private static void createSnapshotWithWorkingClusterWithTheSameEdsVersion(
-      DiscoveryRequest request,
-      ExecutorService executorService
-  ) {
-    if (request.getTypeUrl().equals(Resources.V2.CLUSTER_TYPE_URL)) {
-      executorService.submit(() -> {
-            try {
-              Thread.sleep(5000);
-            } catch (InterruptedException e) {
-              e.printStackTrace();
-            }
-            cache.setSnapshot(GROUP,
-                V2TestSnapshots.createSnapshot(true,
-                    "upstream",
-                    UPSTREAM.ipAddress(),
-                    EchoContainer.PORT,
-                    "listener0",
-                    LISTENER_PORT,
-                    "route0",
-                    "2"));
-          }
-      );
-    }
+  private static void createSnapshotWithWorkingClusterWithTheSameEdsVersion() {
+    cache.setSnapshot(GROUP,
+        V2TestSnapshots.createSnapshot(true,
+            "upstream",
+            UPSTREAM.ipAddress(),
+            EchoContainer.PORT,
+            "listener0",
+            LISTENER_PORT,
+            "route0",
+            "2"));
   }
 
 
@@ -203,31 +194,21 @@ public class V2DiscoveryServerAdsWarmingClusterIT {
   }
 
 
-  /**
-   * Code has been copied from io.envoyproxy.controlplane.cache.SimpleCache to show specific case when
-   * Envoy might stuck with warming cluster. Class has changed lines from method respondWithSpecificOrder which are
-   * responsible for responding for watches. Because to reproduce this problem we need a lot of connected Envoy's and
-   * changes to snapshot it is easier to reproduce this way.
+  /*
+   * In the previous versions of this tests we had a copied SimpleCache with respondWithSpecificOrder removed.
+   * With new versions of Envoy hitting this edge-case became highly improbable.
+   * Now this test checks only if a CDS change will also send EDS.
+   * 1. Envoy connects to control-plane
+   * 2. Snapshot already exists in control-plane <- other instance share same group
+   * 3. Control-plane respond with CDS in createWatch method
+   * 4. There is snapshot update which change CDS and EDS versions
+   * 5. Envoy sends EDS request
+   * 6. Control-plane respond with EDS in createWatch method
+   * 7. Envoy resume CDS and EDS requests.
+   * 8. Envoy sends request CDS
+   * 9. Control plane respond with CDS in createWatch method
+   * 10. Envoy sends EDS requests
+   * 11. Control plane doesn't respond because version hasn't changed
+   * 12. Cluster of service stays in warming phase
    */
-  static class CustomCache<T> extends SimpleCache<T> {
-
-    public CustomCache(NodeGroup<T> groups) {
-      super(groups);
-    }
-
-    // With new versions of Envoy hitting this edge-case became highly improbable
-    // Now this test checks only if a CDS change will also send EDS
-    // 1. Envoy connects to control-plane
-    // 2. Snapshot already exists in control-plane <- other instance share same group
-    // 3. Control-plane respond with CDS in createWatch method
-    // 4. There is snapshot update which change CDS and EDS versions
-    // 5. Envoy sends EDS request
-    // 6. Control-plane respond with EDS in createWatch method
-    // 7. Envoy resume CDS and EDS requests.
-    // 8. Envoy sends request CDS
-    // 9. Control plane respond with CDS in createWatch method
-    // 10. Envoy sends EDS requests
-    // 11. Control plane doesn't respond because version hasn't changed
-    // 12. Cluster of service stays in warming phase
-  }
 }

--- a/server/src/test/java/io/envoyproxy/controlplane/server/V3DiscoveryServerAdsWarmingClusterIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/V3DiscoveryServerAdsWarmingClusterIT.java
@@ -8,7 +8,6 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsString;
 
 import com.google.protobuf.util.Durations;
-import io.envoyproxy.controlplane.cache.CacheStatusInfo;
 import io.envoyproxy.controlplane.cache.NodeGroup;
 import io.envoyproxy.controlplane.cache.Resources;
 import io.envoyproxy.controlplane.cache.TestResources;
@@ -26,7 +25,6 @@ import io.envoyproxy.envoy.service.discovery.v3.DiscoveryRequest;
 import io.envoyproxy.envoy.service.discovery.v3.DiscoveryResponse;
 import io.grpc.netty.NettyServerBuilder;
 import io.restassured.http.ContentType;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -138,26 +136,34 @@ public class V3DiscoveryServerAdsWarmingClusterIT {
 
     String baseUri = String.format("http://%s:%d", ENVOY.getContainerIpAddress(), ENVOY.getMappedPort(LISTENER_PORT));
 
-    await().atMost(5, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
+    await().atMost(15, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
         () -> given().baseUri(baseUri).contentType(ContentType.TEXT)
             .when().get("/")
             .then().statusCode(200)
             .and().body(containsString(UPSTREAM.response)));
   }
 
-  private static void createSnapshotWithWorkingClusterWithTheSameEdsVersion(DiscoveryRequest request,
-      ExecutorService executorService) {
+  private static void createSnapshotWithWorkingClusterWithTheSameEdsVersion(
+      DiscoveryRequest request,
+      ExecutorService executorService
+  ) {
     if (request.getTypeUrl().equals(Resources.V3.CLUSTER_TYPE_URL)) {
-      executorService.submit(() -> cache.setSnapshot(
-          GROUP,
-          createSnapshot(true,
-              "upstream",
-              UPSTREAM.ipAddress(),
-              EchoContainer.PORT,
-              "listener0",
-              LISTENER_PORT,
-              "route0",
-              "2"))
+      executorService.submit(() -> {
+            try {
+              Thread.sleep(5000);
+            } catch (InterruptedException e) {
+              e.printStackTrace();
+            }
+            cache.setSnapshot(GROUP,
+                createSnapshot(true,
+                    "upstream",
+                    UPSTREAM.ipAddress(),
+                    EchoContainer.PORT,
+                    "listener0",
+                    LISTENER_PORT,
+                    "route0",
+                    "2"));
+          }
       );
     }
   }
@@ -217,22 +223,19 @@ public class V3DiscoveryServerAdsWarmingClusterIT {
       super(groups);
     }
 
-    @Override
-    protected void respondWithSpecificOrder(T group, Snapshot snapshot,
-        ConcurrentMap<Resources.ResourceType, CacheStatusInfo<T>> status) {
-      // This code has been removed to show specific case which is hard to reproduce in integration test:
-      //      1. Envoy connects to control-plane
-      //      2. Snapshot already exists in control-plane <- other instance share same group
-      //      3. Control-plane respond with CDS in createWatch method
-      //      4. There is snapshot update which change CDS and EDS versions
-      //      5. Envoy sends EDS request
-      //      6. Control-plane respond with EDS in createWatch method
-      //      7. Envoy resume CDS and EDS requests.
-      //      8. Envoy sends request CDS
-      //      9. Control plane respond with CDS in createWatch method
-      //      10. Envoy sends EDS requests
-      //      11. Control plane doesn't respond because version hasn't changed
-      //      12. Cluster of service stays in warming phase
-    }
+    // With new versions of Envoy hitting this edge-case became highly improbable
+    // Now this test checks only if a CDS change will also send EDS
+    // 1. Envoy connects to control-plane
+    // 2. Snapshot already exists in control-plane <- other instance share same group
+    // 3. Control-plane respond with CDS in createWatch method
+    // 4. There is snapshot update which change CDS and EDS versions
+    // 5. Envoy sends EDS request
+    // 6. Control-plane respond with EDS in createWatch method
+    // 7. Envoy resume CDS and EDS requests.
+    // 8. Envoy sends request CDS
+    // 9. Control plane respond with CDS in createWatch method
+    // 10. Envoy sends EDS requests
+    // 11. Control plane doesn't respond because version hasn't changed
+    // 12. Cluster of service stays in warming phase
   }
 }


### PR DESCRIPTION
pinging @lukidzi as the original author of the test. The original tests succeed only in [1 per ~10 tests](https://app.circleci.com/pipelines/github/envoyproxy/java-control-plane?branch=master). I think this is because we use `envoy:latests` in our docker image setup and hitting this edge case became less probable over time. The change I suggest here [still hits this statement](https://github.com/envoyproxy/java-control-plane/pull/131/files#diff-365acc783365f5bf5c56440076a23e9dR134) as shown by coverage report. attached below:

[coverage reports.zip](https://github.com/envoyproxy/java-control-plane/files/5263492/coverage.reports.zip)

![image](https://user-images.githubusercontent.com/2753650/93926220-870be400-fd17-11ea-887d-43d3ea9692fc.png)

the ordering check is not hit because I removed the "empty" respondInOrder (now it *does* respond in order so I'm guessing that's why the ordering check is not hit).

I run this version multiple times and it succeeded 5 times in a row - https://app.circleci.com/pipelines/github/envoyproxy/java-control-plane?branch=fix-warming-clusters-test so I think it's stable.

Please let me know if this is an acceptable compromise for making this test pass other things we might consider:
- disabling the tests on CI
- reworking the tests to explicitly call "respond" (also add VisibleForTesting - but I do not think this is a great idea)

Signed-off-by: slonka <slonka@users.noreply.github.com>