### PR TITLE
[cluster.proto v3] Update schema to latest version

### DIFF
--- a/api/src/main/proto/envoy/config/cluster/v3/cluster.proto
+++ b/api/src/main/proto/envoy/config/cluster/v3/cluster.proto
@@ -797,6 +797,9 @@ message Cluster {
   // of 0 would indicate that none of the timeout was used or that the timeout was infinite. A value
   // of 100 would indicate that the request took the entirety of the timeout given to it.
   bool track_timeout_budgets = 47;
+
+  // Configuration to track optional cluster stats.
+  TrackClusterStats track_cluster_stats = 49;
 }
 
 // [#not-implemented-hide:] Extensible load balancing policy configuration.
@@ -856,4 +859,18 @@ message UpstreamConnectionOptions {
 
   // If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
   core.v3.TcpKeepalive tcp_keepalive = 1;
+}
+
+message TrackClusterStats {
+  // If timeout_budgets is true, the :ref:`timeout budget histograms
+  // <config_cluster_manager_cluster_stats_timeout_budgets>` will be published for each
+  // request. These show what percentage of a request's per try and global timeout was used. A value
+  // of 0 would indicate that none of the timeout was used or that the timeout was infinite. A value
+  // of 100 would indicate that the request took the entirety of the timeout given to it.
+  bool timeout_budgets = 1;
+
+  // If request_response_sizes is true, then the :ref:`histograms
+  // <config_cluster_manager_cluster_stats_request_response_sizes>`  tracking header and body sizes
+  // of requests and responses will be published.
+  bool request_response_sizes = 2;
 }

--- a/api/src/main/proto/envoy/config/cluster/v3/cluster.proto
+++ b/api/src/main/proto/envoy/config/cluster/v3/cluster.proto
@@ -8,6 +8,7 @@ import "envoy/config/cluster/v3/outlier_detection.proto";
 import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
+import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/health_check.proto";
 import "envoy/config/core/v3/protocol.proto";
 import "envoy/config/endpoint/v3/endpoint.proto";
@@ -798,8 +799,31 @@ message Cluster {
   // of 100 would indicate that the request took the entirety of the timeout given to it.
   bool track_timeout_budgets = 47;
 
+  // Optional customization and configuration of upstream connection pool, and upstream type.
+  //
+  // Currently this field only applies for HTTP traffic but is designed for eventual use for custom
+  // TCP upstreams.
+  //
+  // For HTTP traffic, Envoy will generally take downstream HTTP and send it upstream as upstream
+  // HTTP, using the http connection pool and the codec from `http2_protocol_options`
+  //
+  // For routes where CONNECT termination is configured, Envoy will take downstream CONNECT
+  // requests and forward the CONNECT payload upstream over raw TCP using the tcp connection pool.
+  //
+  // The default pool used is the generic connection pool which creates the HTTP upstream for most
+  // HTTP requests, and the TCP upstream if CONNECT termination is configured.
+  //
+  // If users desire custom connection pool or upstream behavior, for example terminating
+  // CONNECT only if a custom filter indicates it is appropriate, the custom factories
+  // can be registered and configured here.
+  core.v3.TypedExtensionConfig upstream_config = 48;
+
   // Configuration to track optional cluster stats.
   TrackClusterStats track_cluster_stats = 49;
+
+  // If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
+  // connection pool for every downstream connection
+  bool connection_pool_per_downstream_connection = 51;
 }
 
 // [#not-implemented-hide:] Extensible load balancing policy configuration.

--- a/api/src/main/proto/envoy/config/core/v3/extension.proto
+++ b/api/src/main/proto/envoy/config/core/v3/extension.proto
@@ -1,0 +1,59 @@
+syntax = "proto3";
+
+package envoy.config.core.v3;
+
+import "envoy/config/core/v3/config_source.proto";
+
+import "google/protobuf/any.proto";
+
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v3";
+option java_outer_classname = "ExtensionProto";
+option java_multiple_files = true;
+
+// [#protodoc-title: Extension configuration]
+
+// Message type for extension configuration.
+// [#next-major-version: revisit all existing typed_config that doesn't use this wrapper.].
+message TypedExtensionConfig {
+  // The name of an extension. This is not used to select the extension, instead
+  // it serves the role of an opaque identifier.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The typed config for the extension. The type URL will be used to identify
+  // the extension. In the case that the type URL is *udpa.type.v1.TypedStruct*,
+  // the inner type URL of *TypedStruct* will be utilized. See the
+  // :ref:`extension configuration overview
+  // <config_overview_extension_configuration>` for further details.
+  google.protobuf.Any typed_config = 2 [(validate.rules).any = {required: true}];
+}
+
+// Configuration source specifier for a late-bound extension configuration. The
+// parent resource is warmed until all the initial extension configurations are
+// received, unless the flag to apply the default configuration is set.
+// Subsequent extension updates are atomic on a per-worker basis. Once an
+// extension configuration is applied to a request or a connection, it remains
+// constant for the duration of processing. If the initial delivery of the
+// extension configuration fails, due to a timeout for example, the optional
+// default configuration is applied. Without a default configuration, the
+// extension is disabled, until an extension configuration is received. The
+// behavior of a disabled extension depends on the context. For example, a
+// filter chain with a disabled extension filter rejects all incoming streams.
+message ExtensionConfigSource {
+  ConfigSource config_source = 1 [(validate.rules).any = {required: true}];
+
+  // Optional default configuration to use as the initial configuration if
+  // there is a failure to receive the initial extension configuration or if
+  // `apply_default_config_without_warming` flag is set.
+  google.protobuf.Any default_config = 2;
+
+  // Use the default config as the initial configuration without warming and
+  // waiting for the first discovery response. Requires the default configuration
+  // to be supplied.
+  bool apply_default_config_without_warming = 3;
+
+  // A set of permitted extension type URLs. Extension configuration updates are rejected
+  // if they do not match any type URL in the set.
+  repeated string type_urls = 4 [(validate.rules).repeated = {min_items: 1}];
+}

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/TestResources.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/TestResources.java
@@ -34,6 +34,7 @@ import io.envoyproxy.envoy.api.v2.route.Route;
 import io.envoyproxy.envoy.api.v2.route.RouteAction;
 import io.envoyproxy.envoy.api.v2.route.RouteMatch;
 import io.envoyproxy.envoy.api.v2.route.VirtualHost;
+import io.envoyproxy.envoy.config.cluster.v3.TrackClusterStats;
 import io.envoyproxy.envoy.config.core.v3.ApiVersion;
 import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager;
 import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager.CodecType;
@@ -142,6 +143,7 @@ public class TestResources {
                                 .setProtocolValue(Protocol.TCP_VALUE)))))
             )
         )
+        .setTrackClusterStats(TrackClusterStats.newBuilder().setRequestResponseSizes(true).build())
         .build();
   }
 

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/TestResources.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/TestResources.java
@@ -34,7 +34,6 @@ import io.envoyproxy.envoy.api.v2.route.Route;
 import io.envoyproxy.envoy.api.v2.route.RouteAction;
 import io.envoyproxy.envoy.api.v2.route.RouteMatch;
 import io.envoyproxy.envoy.api.v2.route.VirtualHost;
-import io.envoyproxy.envoy.config.cluster.v3.TrackClusterStats;
 import io.envoyproxy.envoy.config.core.v3.ApiVersion;
 import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager;
 import io.envoyproxy.envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager.CodecType;
@@ -143,7 +142,6 @@ public class TestResources {
                                 .setProtocolValue(Protocol.TCP_VALUE)))))
             )
         )
-        .setTrackClusterStats(TrackClusterStats.newBuilder().setRequestResponseSizes(true).build())
         .build();
   }
 


### PR DESCRIPTION
Currently cluster.proto schema is lagging behind the one available in Envoy repo. Added fields available in envoy v3 cluster api . Made no changes to api v2, as it is being deprecated. 

Fields that are currently missing: 

```
  core.v3.TypedExtensionConfig upstream_config = 48;

  // Configuration to track optional cluster stats.
  TrackClusterStats track_cluster_stats = 49;

  // If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
  // connection pool for every downstream connection
  bool connection_pool_per_downstream_connection = 51;
```
Could not find any tests for newly added fields, need to come up with approach.