### PR TITLE
used wildcards instead of  include

### DIFF
--- a/tools/update-api.sh
+++ b/tools/update-api.sh
@@ -29,11 +29,11 @@ pushd "${tmpdir}" >/dev/null
 
 rm -rf "${protodir}"
 
-curl -sL https://github.com/envoyproxy/envoy/archive/${ENVOY_SHA}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/envoyproxy/envoy/archive/${ENVOY_SHA}.tar.gz | tar xz --wildcards="*.proto"
 mkdir -p "${protodir}/envoy"
 cp -r envoy-*/api/envoy/* "${protodir}/envoy"
 
-curl -sL https://github.com/googleapis/googleapis/archive/${GOOGLEAPIS_SHA}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/googleapis/googleapis/archive/${GOOGLEAPIS_SHA}.tar.gz | tar xz --wildcards="*.proto"
 mkdir -p "${protodir}/google/api"
 mkdir -p "${protodir}/google/api/expr/v1alpha1"
 mkdir -p "${protodir}/google/rpc"
@@ -42,18 +42,18 @@ cp googleapis-*/google/api/expr/v1alpha1/syntax.proto "${protodir}/google/api/ex
 cp googleapis-*/google/api/expr/v1alpha1/checked.proto "${protodir}/google/api/expr/v1alpha1"
 cp googleapis-*/google/rpc/status.proto "${protodir}/google/rpc"
 
-curl -sL https://github.com/envoyproxy/protoc-gen-validate/archive/${PGV_GIT_SHA}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/envoyproxy/protoc-gen-validate/archive/${PGV_GIT_SHA}.tar.gz | tar xz --wildcards="*.proto"
 mkdir -p "${protodir}/validate"
 cp -r protoc-gen-validate-*/validate/* "${protodir}/validate"
 
-curl -sL https://github.com/census-instrumentation/opencensus-proto/archive/v${OPENCENSUS_VERSION}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/census-instrumentation/opencensus-proto/archive/v${OPENCENSUS_VERSION}.tar.gz | tar xz --wildcards="*.proto"
 mkdir -p "${protodir}/opencensus/proto"
 cp -r opencensus-proto-*/src/opencensus/proto/* "${protodir}/opencensus/proto"
 
-curl -sL https://github.com/prometheus/client_model/archive/${PROMETHEUS_SHA}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/prometheus/client_model/archive/${PROMETHEUS_SHA}.tar.gz | tar xz --wildcards="*.proto"
 cp client_model-*/metrics.proto "${protodir}"
 
-curl -sL https://github.com/cncf/udpa/archive/${UDPA_SHA}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/cncf/udpa/archive/${UDPA_SHA}.tar.gz | tar xz --wildcards="*.proto"
 mkdir -p "${protodir}/udpa"
 mkdir -p "${protodir}/xds"
 cp -r udpa-*/udpa/* "${protodir}/udpa"


### PR DESCRIPTION
--wildcards works with many tar distributions including the one used in windows based systems.