### PR TITLE
Generate Kotlin gRPC Stubs

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,9 +28,21 @@
         </dependency>
 
         <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-kotlin-stub</artifactId>
+            <version>${grpc-kotlin.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>${protobuf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+            <version>${kotlin-coroutines.version}</version>
         </dependency>
 
         <dependency>
@@ -46,7 +58,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.5.0.Final</version>
+                <version>1.6.2</version>
             </extension>
         </extensions>
         <plugins>
@@ -58,6 +70,16 @@
                     <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                    <protocPlugins>
+                        <protocPlugin>
+                            <id>grpc-kotlin</id>
+                            <groupId>io.grpc</groupId>
+                            <artifactId>protoc-gen-grpc-kotlin</artifactId>
+                            <version>${grpc-kotlin.version}</version>
+                            <classifier>jdk7</classifier>
+                            <mainClass>io.grpc.kotlin.generator.GeneratorRunner</mainClass>
+                        </protocPlugin>
+                    </protocPlugins>
 
                     <useArgumentFile>true</useArgumentFile>
                     <checkStaleness>true</checkStaleness>
@@ -65,9 +87,30 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <id>compile</id>
                         <goals>
                             <goal>compile</goal>
                             <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,13 @@
         <auto-value.version>1.6.3</auto-value.version>
         <awaitility.version>3.1.6</awaitility.version>
         <checkstyle.version>8.18</checkstyle.version>
-        <grpc.version>1.22.1</grpc.version>
-        <guava.version>26.0-android</guava.version><!-- Keep the Guava version in sync with grpc-java -->
+        <grpc.version>1.36.0</grpc.version>
+        <grpc-kotlin.version>1.1.0</grpc-kotlin.version><!-- Keep the gRPC Kotlin version in sync with grpc-java -->
+        <guava.version>30.0-android</guava.version><!-- Keep the Guava version in sync with grpc-java -->
         <junit.version>4.13.1</junit.version>
-        <protobuf.version>3.9.1</protobuf.version><!-- Keep the Protobuf version in sync with grpc-java -->
+        <kotlin.version>1.3.61</kotlin.version><!-- Keep the Kotlin version in sync with grpc-kotlin -->
+        <kotlin-coroutines.version>1.3.3</kotlin-coroutines.version><!-- Keep the Kotlin Coroutines version in sync with grpc-kotlin -->
+        <protobuf.version>3.12.0</protobuf.version><!-- Keep the Protobuf version in sync with grpc-java -->
         <rest-assured.version>3.1.0</rest-assured.version>
         <slf4j.version>1.7.26</slf4j.version>
         <testcontainers.version>1.15.3</testcontainers.version>


### PR DESCRIPTION
This patch modifies build configuration files to generate gRPC Stubs for Kotlin and place them inside the built artifact. The changes were based on official tutorials on how to configure maven-protobuf-plugin to generate Kotlin gRPC Stubs (https://github.com/grpc/grpc-kotlin/tree/master/compiler) and how to build Kotlin with Maven (https://kotlinlang.org/docs/maven.html).

In the built JAR, for each ServiceGrpc class generated from a gRPC service definition on proto files, a new class called ServiceGrpcKt is introduced with the Kotlin interface. I've tested it on a Java-only project to make sure it doesn't cause any problem.

![image](https://user-images.githubusercontent.com/7753096/120906014-6cbb3180-c62c-11eb-9c62-9abb099688d8.png)

The built artifact is available on JitPack: https://jitpack.io/#t0rr3sp3dr0/java-control-plane/3bd90153d9.

Closes #168