### PR TITLE
docs: remove jakubdyszkiewicz from OWNERS.md

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -11,7 +11,6 @@
 * Garrett Bourg ([baojr](https://github.com/baojr)) (bourg@squareup.com)
 * Michael Puncel ([mpuncel](https://github.com/mpuncel)) (mpuncel@squareup.com)
 * Dariusz Jędrzejczyk ([chemicL](https://github.com/chemicL)) (dariusz.jedrzejczyk@allegro.pl)
-* Jakub Dyszkiewicz ([jakubdyszkiewicz](https://github.com/jakubdyszkiewicz)) (jakub.dyszkiewicz@gmail.com)
 * Krzysztof Słonka ([slonka](https://github.com/slonka)) (krzysztof.slonka@allegro.pl)
 * Łukasz Dziedziak ([lukidzi](https://github.com/lukidzi)) (lukasz.dziedziak@allegro.pl)
 * Kateryna Nezdolii ([nezdolik](https://github.com/nezdolik)) (nezdolik@spotify.com)


### PR DESCRIPTION
As much as I'd love to keep a status of a maintainer of `java-control-plane`, I simply do not have time at this moment to contribute.

See you in the other envoy related projects!