### PR TITLE
Bump default "no output" timeout of 10 minutes for build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,9 @@ jobs:
           - v1-dependencies-
 
       # Build
-      - run: mvn -B install -DskipTests -Dmaven.javadoc.skip=true dependency:go-offline
+      - run:
+          command: mvn -B install -DskipTests -Dmaven.javadoc.skip=true dependency:go-offline
+          no_output_timeout: 20m
 
       # Save the dependency cache for future runs
       - save_cache:


### PR DESCRIPTION
CircleCI has a default "no output" timeout of 10 minutes, after which a build will fail (see https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-hit-timeout-limit). This causes the build pipeline to - at times - fail during the mvn build step, as there can be certain tasks in maven that don't output anything for longer than this timeout.

So I am doubling the timeout period to - hopefully - make the build pipeline less prone to flaky failures.

@onemanbucket Can you please take a look?