### PR TITLE
deprecate v2

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/v2/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/v2/SimpleCache.java
@@ -2,6 +2,7 @@ package io.envoyproxy.controlplane.cache.v2;
 
 import io.envoyproxy.controlplane.cache.NodeGroup;
 
+@Deprecated
 public class SimpleCache<T> extends io.envoyproxy.controlplane.cache.SimpleCache<T, Snapshot> {
   public SimpleCache(NodeGroup<T> nodeGroup) {
     super(nodeGroup);

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/v2/Snapshot.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/v2/Snapshot.java
@@ -25,6 +25,7 @@ import java.util.Set;
  * {@code Snapshot} is a data class that contains an internally consistent snapshot of v2 xDS
  * resources. Snapshots should have distinct versions per node group.
  */
+@Deprecated
 @AutoValue
 public abstract class Snapshot extends io.envoyproxy.controlplane.cache.Snapshot {
 

--- a/server/src/main/java/io/envoyproxy/controlplane/server/V2DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/V2DiscoveryServer.java
@@ -20,10 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * @deprecated Envoy has removed support for v2 xDS API.
- */
-@Deprecated(forRemoval = true, since = "0.1.31")
+@Deprecated
 public class V2DiscoveryServer extends DiscoveryServer<DiscoveryRequest, DiscoveryResponse> {
 
   public V2DiscoveryServer(ConfigWatcher configWatcher) {

--- a/server/src/main/java/io/envoyproxy/controlplane/server/V2DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/V2DiscoveryServer.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+@Deprecated(forRemoval = true, since = "0.1.31")
 public class V2DiscoveryServer extends DiscoveryServer<DiscoveryRequest, DiscoveryResponse> {
 
   public V2DiscoveryServer(ConfigWatcher configWatcher) {

--- a/server/src/main/java/io/envoyproxy/controlplane/server/V2DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/V2DiscoveryServer.java
@@ -20,6 +20,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * @deprecated Envoy has removed support for v2 xDS API.
+ */
 @Deprecated(forRemoval = true, since = "0.1.31")
 public class V2DiscoveryServer extends DiscoveryServer<DiscoveryRequest, DiscoveryResponse> {
 


### PR DESCRIPTION
Deprecate V2 and mark for removal, since Envoy has now removed support for v2 xDS API.