### PR TITLE
Fix gitHub action to upgrade envoy protos

### DIFF
--- a/.github/workflows/update-protobuf.yml
+++ b/.github/workflows/update-protobuf.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Run scripts
         working-directory: ./tools/
         run: |
-          ./update-sha.sh ${{ github.event.inputs.envoy_version }} | tee /dev/tty > API_SHAS
+          ./update-sha.sh ${{ github.event.inputs.envoy_version }} | tee API_SHAS
           ./update-api.sh
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/tools/update-api.sh
+++ b/tools/update-api.sh
@@ -30,11 +30,11 @@ pushd "${tmpdir}" >/dev/null
 
 rm -rf "${protodir}"
 
-curl -sL https://github.com/envoyproxy/envoy/archive/${ENVOY_SHA}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/envoyproxy/envoy/archive/${ENVOY_SHA}.tar.gz | tar xz --wildcards '*.proto'
 mkdir -p "${protodir}/envoy"
 cp -r envoy-*/api/envoy/* "${protodir}/envoy"
 
-curl -sL https://github.com/googleapis/googleapis/archive/${GOOGLEAPIS_SHA}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/googleapis/googleapis/archive/${GOOGLEAPIS_SHA}.tar.gz | tar xz --wildcards '*.proto'
 mkdir -p "${protodir}/google/api"
 mkdir -p "${protodir}/google/api/expr/v1alpha1"
 mkdir -p "${protodir}/google/rpc"
@@ -43,25 +43,25 @@ cp googleapis-*/google/api/expr/v1alpha1/syntax.proto "${protodir}/google/api/ex
 cp googleapis-*/google/api/expr/v1alpha1/checked.proto "${protodir}/google/api/expr/v1alpha1"
 cp googleapis-*/google/rpc/status.proto "${protodir}/google/rpc"
 
-curl -sL https://github.com/envoyproxy/protoc-gen-validate/archive/v${PGV_VERSION}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/envoyproxy/protoc-gen-validate/archive/v${PGV_VERSION}.tar.gz | tar xz --wildcards '*.proto'
 mkdir -p "${protodir}/validate"
 cp -r protoc-gen-validate-*/validate/* "${protodir}/validate"
 
-curl -sL https://github.com/census-instrumentation/opencensus-proto/archive/v${OPENCENSUS_VERSION}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/census-instrumentation/opencensus-proto/archive/v${OPENCENSUS_VERSION}.tar.gz | tar xz --wildcards '*.proto'
 mkdir -p "${protodir}/opencensus/proto"
 cp -r opencensus-proto-*/src/opencensus/proto/* "${protodir}/opencensus/proto"
 
-curl -sL https://github.com/prometheus/client_model/archive/${PROMETHEUS_SHA}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/prometheus/client_model/archive/${PROMETHEUS_SHA}.tar.gz | tar xz --wildcards '*.proto'
 mkdir -p "${protodir}/io/prometheus/client/"
 cp client_model-*/io/prometheus/client/metrics.proto "${protodir}/io/prometheus/client/"
 
-curl -sL https://github.com/cncf/xds/archive/${UDPA_SHA}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/cncf/xds/archive/${UDPA_SHA}.tar.gz | tar xz --wildcards '*.proto'
 mkdir -p "${protodir}/udpa"
 mkdir -p "${protodir}/xds"
 cp -r xds-*/udpa/* "${protodir}/udpa"
 cp -r xds-*/xds/* "${protodir}/xds"
 
-curl -sL https://github.com/open-telemetry/opentelemetry-proto/archive/v${OPENTELEMETRY_VERSION}.tar.gz | tar xz --include="*.proto"
+curl -sL https://github.com/open-telemetry/opentelemetry-proto/archive/v${OPENTELEMETRY_VERSION}.tar.gz | tar xz --wildcards '*.proto'
 mkdir -p "${protodir}/opentelemetry/proto"
 cp -r opentelemetry-proto-*/opentelemetry/proto/* "${protodir}/opentelemetry/proto"
 

--- a/tools/update-sha.sh
+++ b/tools/update-sha.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o xtrace
+
 function find_sha() {
   local CONTENT=$1
   local DEPENDENCY=$2


### PR DESCRIPTION
I had to update a couple of things to get the github action that upgrades the Envoy API to run successfully. 

I have tested it in my fork for Envoy v1.21.0, so the next step would be to configure it to run automatically whenever a new Envoy version is released. 

Here is the PR that was created through the github action -> https://github.com/rulex123/java-control-plane/pulls

@onemanbucket can you take a look when you get a chance?