### PR TITLE
Migrating from Ubuntu 14.04 to Ubuntu 20.04 for Circle CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    machine: true
+    image: ubuntu-2004:202201-02
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
 jobs:
   build:
-    image: ubuntu-2004:202201-02
+    machine:
+      image: ubuntu-2004:202201-02
 
     working_directory: ~/repo
 


### PR DESCRIPTION
As per instructions here
https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/?mkt_tok=NDg1LVpNSC02MjYAAAGCndauQAv9-BZZXCTbKMjSUMJIhX8nGsCwm9FblTbEN75h56uBn3TgzeOFj_a_8CJbpZGZKf7gFRp3Qj2IFgEY3SQmQzG96brfnrsLBJCTXefs#changes

The Ubuntu 14.04 image is being deprecated at the end of May 2022, so this patch updates to the new suggested image for the CircleCI jobs.