### PR TITLE
Try and fix main build pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
               echo $GPG_KEY | base64 --decode > signing-key
-              gpg --passphrase $GPG_PASSPHRASE --import signing-key
+              gpg --batch --passphrase $GPG_PASSPHRASE --import signing-key
               shred signing-key
 
               if [[ -n "${RELEASE}" && -n "${NEXT}" ]]; then
@@ -52,7 +52,7 @@ jobs:
               fi
             elif [[ -n "${DEPLOY_BRANCH}" ]]; then
               echo $GPG_KEY | base64 --decode > signing-key
-              gpg --passphrase $GPG_PASSPHRASE --import signing-key
+              gpg --batch --passphrase $GPG_PASSPHRASE --import signing-key
               shred signing-key
 
               mvn -B -s .circleci/settings-snapshots.xml deploy


### PR DESCRIPTION
The main build pipeline is failing on the gpg import command
(as far as I can gather at least) since the switch to the latest
ubuntu image for CircleCI. I did some troubleshooting rerunning
the failed job with SSH enabled, and it appears that the gpg 
command is running in interactive mode (i.e. asks for passphrase 
input)

Signed-off-by: rulex123 <erica.manno@gmail.com>