### PR TITLE
Small improvements in the generation of the PR that updates the protobuf files

### DIFF
--- a/.github/workflows/update-protobuf.yml
+++ b/.github/workflows/update-protobuf.yml
@@ -26,7 +26,7 @@ jobs:
           committer: envoy-bot <envoy-bot@users.noreply.github.com>
           signoff: true
           title: '[protobuf] Update protobuf definitions to ${{ inputs.envoy_version }}'
-          committ-message: |
+          commit-message: |
             [protobuf] Update protobuf definitions to ${{ inputs.envoy_version }}
           body: |
             This is an automatic PR created by github action workflow:

--- a/.github/workflows/update-protobuf.yml
+++ b/.github/workflows/update-protobuf.yml
@@ -21,8 +21,13 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           branch: update-protobuf-to-${{ inputs.envoy_version }}
+          base: main
+          author: envoy-bot <envoy-bot@users.noreply.github.com>
+          committer: envoy-bot <envoy-bot@users.noreply.github.com>
           signoff: true
           title: '[protobuf] Update protobuf definitions to ${{ inputs.envoy_version }}'
+          committ-message: |
+            [protobuf] Update protobuf definitions to ${{ inputs.envoy_version }}
           body: |
             This is an automatic PR created by github action workflow:
             - Updated protobuf files


### PR DESCRIPTION
I am tweaking the params of the Github action that we use to 
automatically open PRs when a new Envoy release is available.
I have added config for commit msg, PR author etc.