### PR TITLE
Remove --bootstrap-version when starting up Envoy test container

### DIFF
--- a/server/src/test/java/io/envoyproxy/controlplane/server/EnvoyContainer.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/EnvoyContainer.java
@@ -12,7 +12,6 @@ class EnvoyContainer extends GenericContainer<EnvoyContainer> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(EnvoyContainer.class);
 
-  private static final int DEFAULT_API_VERSION = 2;
   private static final String CONFIG_DEST = "/etc/envoy/envoy.yaml";
   private static final String HOST_IP_SCRIPT = "docker/host_ip.sh";
   private static final String HOST_IP_SCRIPT_DEST = "/usr/local/bin/host_ip.sh";
@@ -23,19 +22,13 @@ class EnvoyContainer extends GenericContainer<EnvoyContainer> {
 
   private final String config;
   private final Supplier<Integer> controlPlanePortSupplier;
-  private final int apiVersion;
 
   EnvoyContainer(String config, Supplier<Integer> controlPlanePortSupplier) {
-    this(config, controlPlanePortSupplier, DEFAULT_API_VERSION);
-  }
-
-  EnvoyContainer(String config, Supplier<Integer> controlPlanePortSupplier, int apiVersion) {
     // this version is changed automatically by /tools/update-sha.sh:57
     // if you change it make sure to reflect changes there
     super("envoyproxy/envoy-alpine-dev:bef18019d8fc33a4ed6aca3679aff2100241ac5e");
     this.config = config;
     this.controlPlanePortSupplier = controlPlanePortSupplier;
-    this.apiVersion = apiVersion;
   }
 
   @Override
@@ -50,8 +43,7 @@ class EnvoyContainer extends GenericContainer<EnvoyContainer> {
         "/bin/sh", "/usr/local/bin/launch_envoy.sh",
         Integer.toString(controlPlanePortSupplier.get()),
         CONFIG_DEST,
-        "-l", "debug",
-        "--bootstrap-version", Integer.toString(apiVersion)
+        "-l", "debug"
     );
 
     getExposedPorts().add(0, ADMIN_PORT);

--- a/server/src/test/java/io/envoyproxy/controlplane/server/V3DiscoveryServerAdsIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/V3DiscoveryServerAdsIT.java
@@ -23,7 +23,6 @@ public class V3DiscoveryServerAdsIT {
   private static final String CONFIG = "envoy/ads.v3.config.yaml";
   private static final String GROUP = "key";
   private static final Integer LISTENER_PORT = 10000;
-  private static final int API_VERSION = 3;
 
   private static final CountDownLatch onStreamOpenLatch = new CountDownLatch(1);
   private static final CountDownLatch onStreamRequestLatch = new CountDownLatch(1);
@@ -68,7 +67,7 @@ public class V3DiscoveryServerAdsIT {
 
   private static final Network NETWORK = Network.newNetwork();
 
-  private static final EnvoyContainer ENVOY = new EnvoyContainer(CONFIG, () -> ADS.getServer().getPort(), API_VERSION)
+  private static final EnvoyContainer ENVOY = new EnvoyContainer(CONFIG, () -> ADS.getServer().getPort())
       .withExposedPorts(LISTENER_PORT)
       .withNetwork(NETWORK);
 

--- a/server/src/test/java/io/envoyproxy/controlplane/server/V3DiscoveryServerAdsWarmingClusterIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/V3DiscoveryServerAdsWarmingClusterIT.java
@@ -38,7 +38,6 @@ public class V3DiscoveryServerAdsWarmingClusterIT {
   private static final String CONFIG = "envoy/ads.v3.config.yaml";
   private static final String GROUP = "key";
   private static final Integer LISTENER_PORT = 10000;
-  private static final int API_VERSION = 3;
   private static final SimpleCache<String> cache = new SimpleCache<>(new NodeGroup<String>() {
     @Override public String hash(Node node) {
       throw new IllegalStateException("Unexpected v2 request in v3 test");
@@ -104,7 +103,7 @@ public class V3DiscoveryServerAdsWarmingClusterIT {
 
   private static final Network NETWORK = Network.newNetwork();
 
-  private static final EnvoyContainer ENVOY = new EnvoyContainer(CONFIG, () -> ADS.getServer().getPort(), API_VERSION)
+  private static final EnvoyContainer ENVOY = new EnvoyContainer(CONFIG, () -> ADS.getServer().getPort())
       .withExposedPorts(LISTENER_PORT)
       .withNetwork(NETWORK);
 

--- a/server/src/test/java/io/envoyproxy/controlplane/server/V3DiscoveryServerXdsIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/V3DiscoveryServerXdsIT.java
@@ -23,7 +23,6 @@ public class V3DiscoveryServerXdsIT {
   private static final String CONFIG = "envoy/xds.v3.config.yaml";
   private static final String GROUP = "key";
   private static final Integer LISTENER_PORT = 10000;
-  private static final int API_VERSION = 3;
 
   private static final CountDownLatch onStreamOpenLatch = new CountDownLatch(2);
   private static final CountDownLatch onStreamRequestLatch = new CountDownLatch(2);
@@ -69,7 +68,7 @@ public class V3DiscoveryServerXdsIT {
 
   private static final Network NETWORK = Network.newNetwork();
 
-  private static final EnvoyContainer ENVOY = new EnvoyContainer(CONFIG, () -> XDS.getServer().getPort(), API_VERSION)
+  private static final EnvoyContainer ENVOY = new EnvoyContainer(CONFIG, () -> XDS.getServer().getPort())
       .withExposedPorts(LISTENER_PORT)
       .withNetwork(NETWORK);
 


### PR DESCRIPTION
Remove --bootstrap-version from args in envoy test container,
since this has been removed from the availble command line args.

Signed-off-by: rulex123 <erica.manno@gmail.com>