### PR TITLE
Update Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,10 @@
         <auto-value.version>1.6.3</auto-value.version>
         <awaitility.version>3.1.6</awaitility.version>
         <checkstyle.version>8.18</checkstyle.version>
-        <grpc.version>1.22.1</grpc.version>
-        <guava.version>26.0-android</guava.version><!-- Keep the Guava version in sync with grpc-java -->
+        <grpc.version>1.48.1</grpc.version>
+        <guava.version>31.1-android</guava.version><!-- Keep the Guava version in sync with grpc-java -->
         <junit.version>4.13.1</junit.version>
-        <protobuf.version>3.9.1</protobuf.version><!-- Keep the Protobuf version in sync with grpc-java -->
+        <protobuf.version>3.21.5</protobuf.version><!-- Keep the Protobuf version in sync with grpc-java -->
         <rest-assured.version>3.1.0</rest-assured.version>
         <slf4j.version>1.7.26</slf4j.version>
         <testcontainers.version>1.17.1</testcontainers.version>


### PR DESCRIPTION
## Description

There are a couple CVEs in both the Java Protobuf `java-protobuf` [[Ref]](https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java/3.9.1) and the Guava Cache `guava-android` [[Ref]](https://mvnrepository.com/artifact/com.google.guava/guava/26.0-android) versions that we are currently using.

- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569

## Changes

This PR bumps up the dependencies to a newer version which doesn't have any CVEs. These are the dependencies that we are bumping the versions for:

- **GRPC:** 1.22.1 -> 1.48.1
- **Java Protobuf:** 3.9.1 -> 3.21.5
- **Guava Cache:** 26.0 -> 31.1