### PR TITLE
server: allow throwing checked exception from stream callbacks

### DIFF
--- a/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/AdsDiscoveryRequestStreamObserver.java
@@ -5,6 +5,7 @@ import static io.envoyproxy.controlplane.server.DiscoveryServer.ANY_TYPE_URL;
 import io.envoyproxy.controlplane.cache.Resources;
 import io.envoyproxy.controlplane.cache.Watch;
 import io.grpc.Status;
+import io.grpc.StatusException;
 import io.grpc.stub.StreamObserver;
 import java.util.Collections;
 import java.util.Set;
@@ -37,11 +38,8 @@ public class AdsDiscoveryRequestStreamObserver<T, U> extends DiscoveryRequestStr
   @Override
   public void onNext(T request) {
     if (discoveryServer.wrapXdsRequest(request).getTypeUrl().isEmpty()) {
-      closeWithError(
-          Status.UNKNOWN
-              .withDescription(String.format("[%d] type URL is required for ADS", streamId))
-              .asRuntimeException());
-
+      onError(new StatusException(Status.UNKNOWN.withDescription(
+          String.format("[%d] type URL is required for ADS", streamId))));
       return;
     }
 

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DeltaDiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DeltaDiscoveryRequestStreamObserver.java
@@ -67,7 +67,7 @@ public abstract class DeltaDiscoveryRequestStreamObserver<V, X, Y> implements St
     try {
       discoveryServer.runStreamDeltaRequestCallbacks(streamId, rawRequest);
     } catch (RequestException e) {
-      closeWithError(e);
+      onError(e);
       return;
     }
 

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryRequestStreamObserver.java
@@ -70,7 +70,7 @@ public abstract class DiscoveryRequestStreamObserver<T, U> implements StreamObse
     try {
       discoveryServer.runStreamRequestCallbacks(streamId, rawRequest);
     } catch (RequestException e) {
-      closeWithError(e);
+      onError(e);
       return;
     }
 

--- a/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServerCallbacks.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/DiscoveryServerCallbacks.java
@@ -41,8 +41,10 @@ public interface DiscoveryServerCallbacks {
    *
    * @param streamId an ID for this stream that is only unique to this discovery server instance
    * @param typeUrl the resource type of the stream, or {@link DiscoveryServer#ANY_TYPE_URL} for ADS
+   * @throws RequestException can throw {@link RequestException} with custom status. That status
+   *     will be returned to the client and the stream will be closed with error.
    */
-  default void onStreamOpen(long streamId, String typeUrl) {
+  default void onStreamOpen(long streamId, String typeUrl) throws RequestException {
 
   }
 
@@ -53,10 +55,10 @@ public interface DiscoveryServerCallbacks {
    * @param streamId an ID for this stream that is only unique to this discovery server instance
    * @param request the discovery request sent by the envoy instance
    *
-   * @throws RequestException optionally can throw {@link RequestException} with custom status. That status
+   * @throws RequestException can throw {@link RequestException} with custom status. That status
    *     will be returned to the client and the stream will be closed with error.
    */
-  void onV3StreamRequest(long streamId, DiscoveryRequest request);
+  void onV3StreamRequest(long streamId, DiscoveryRequest request) throws RequestException;
 
   /**
    * {@code onV3StreamRequest} is called for each {@link io.envoyproxy.envoy.service.discovery.v3.DeltaDiscoveryRequest}
@@ -65,11 +67,11 @@ public interface DiscoveryServerCallbacks {
    * @param streamId an ID for this stream that is only unique to this discovery server instance
    * @param request the discovery request sent by the envoy instance
    *
-   * @throws RequestException optionally can throw {@link RequestException} with custom status. That status
+   * @throws RequestException can throw {@link RequestException} with custom status. That status
    *     will be returned to the client and the stream will be closed with error.
    */
   void onV3StreamDeltaRequest(long streamId,
-                              DeltaDiscoveryRequest request);
+                              DeltaDiscoveryRequest request) throws RequestException;
 
   /**
    * {@code onV3StreamResponse} is called just before each

--- a/server/src/main/java/io/envoyproxy/controlplane/server/V3DiscoveryServer.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/V3DiscoveryServer.java
@@ -12,6 +12,7 @@ import io.envoyproxy.controlplane.cache.ConfigWatcher;
 import io.envoyproxy.controlplane.cache.DeltaXdsRequest;
 import io.envoyproxy.controlplane.cache.Resources;
 import io.envoyproxy.controlplane.cache.XdsRequest;
+import io.envoyproxy.controlplane.server.exception.RequestException;
 import io.envoyproxy.controlplane.server.serializer.DefaultProtoResourcesSerializer;
 import io.envoyproxy.controlplane.server.serializer.ProtoResourcesSerializer;
 import io.envoyproxy.envoy.service.cluster.v3.ClusterDiscoveryServiceGrpc.ClusterDiscoveryServiceImplBase;
@@ -187,15 +188,17 @@ public class V3DiscoveryServer extends DiscoveryServer<DiscoveryRequest, Discove
   }
 
   @Override
-  protected void runStreamRequestCallbacks(long streamId, DiscoveryRequest discoveryRequest) {
-    callbacks.forEach(
-        cb -> cb.onV3StreamRequest(streamId, discoveryRequest));
+  protected void runStreamRequestCallbacks(long streamId, DiscoveryRequest discoveryRequest) throws RequestException {
+    for (DiscoveryServerCallbacks cb : callbacks) {
+      cb.onV3StreamRequest(streamId, discoveryRequest);
+    }
   }
 
   @Override
-  protected void runStreamDeltaRequestCallbacks(long streamId, DeltaDiscoveryRequest request) {
-    callbacks.forEach(
-        cb -> cb.onV3StreamDeltaRequest(streamId, request));
+  protected void runStreamDeltaRequestCallbacks(long streamId, DeltaDiscoveryRequest request) throws RequestException {
+    for (DiscoveryServerCallbacks cb : callbacks) {
+      cb.onV3StreamDeltaRequest(streamId, request);
+    }
   }
 
   @Override

--- a/server/src/main/java/io/envoyproxy/controlplane/server/exception/RequestException.java
+++ b/server/src/main/java/io/envoyproxy/controlplane/server/exception/RequestException.java
@@ -2,11 +2,10 @@ package io.envoyproxy.controlplane.server.exception;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
-
+import io.grpc.StatusException;
 import javax.annotation.Nullable;
 
-public class RequestException extends StatusRuntimeException {
+public class RequestException extends StatusException {
   public RequestException(Status status) {
     this(status, null);
   }

--- a/server/src/test/java/io/envoyproxy/controlplane/server/V3DiscoveryServerAdsStreamOpenExceptionIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/V3DiscoveryServerAdsStreamOpenExceptionIT.java
@@ -1,0 +1,120 @@
+package io.envoyproxy.controlplane.server;
+
+import static io.envoyproxy.controlplane.server.V3TestSnapshots.createSnapshot;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+
+import io.envoyproxy.controlplane.cache.v3.SimpleCache;
+import io.envoyproxy.controlplane.server.exception.RequestException;
+import io.grpc.Status;
+import io.grpc.netty.NettyServerBuilder;
+import io.restassured.http.ContentType;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.testcontainers.containers.Network;
+
+public class V3DiscoveryServerAdsStreamOpenExceptionIT {
+
+  private static final String CONFIG = "envoy/ads.v3.config.yaml";
+  private static final String GROUP = "key";
+  private static final Integer LISTENER_PORT = 10000;
+
+  private static final CountDownLatch onStreamOpenLatch = new CountDownLatch(1);
+  private static final CountDownLatch onStreamCloseWithErrorLatch = new CountDownLatch(1);
+  private static final CountDownLatch onStreamRequestLatch = new CountDownLatch(1);
+  private static final CountDownLatch onStreamResponseLatch = new CountDownLatch(1);
+
+  private static final NettyGrpcServerRule ADS =
+      new NettyGrpcServerRule() {
+        @Override
+        protected void configureServerBuilder(NettyServerBuilder builder) {
+          final SimpleCache<String> cache = new SimpleCache<>(node -> GROUP);
+          final DiscoveryServerCallbacks callbacks = new V3OnlyDiscoveryServerCallbacks(
+              onStreamOpenLatch, onStreamRequestLatch, onStreamResponseLatch) {
+            @Override public void onStreamOpen(long streamId, String typeUrl) throws RequestException {
+              if (streamId == 0) {
+                throw new RequestException(Status.INVALID_ARGUMENT);
+              } else {
+                onStreamOpenLatch.countDown();
+              }
+            }
+
+            @Override public void onStreamCloseWithError(long streamId, String typeUrl, Throwable error) {
+              onStreamCloseWithErrorLatch.countDown();
+            }
+          };
+
+          cache.setSnapshot(
+              GROUP,
+              createSnapshot(
+                  true,
+                  false,
+                  "upstream",
+                  UPSTREAM.ipAddress(),
+                  EchoContainer.PORT,
+                  "listener0",
+                  LISTENER_PORT,
+                  "route0",
+                  "1"));
+
+          V3DiscoveryServer server = new V3DiscoveryServer(callbacks, cache);
+
+          builder.addService(server.getAggregatedDiscoveryServiceImpl());
+        }
+      };
+
+  private static final Network NETWORK = Network.newNetwork();
+
+  private static final EnvoyContainer ENVOY = new EnvoyContainer(CONFIG, () -> ADS.getServer().getPort())
+      .withExposedPorts(LISTENER_PORT)
+      .withNetwork(NETWORK);
+
+  private static final EchoContainer UPSTREAM =
+      new EchoContainer().withNetwork(NETWORK).withNetworkAliases("upstream");
+
+  @ClassRule
+  public static final RuleChain RULES = RuleChain.outerRule(UPSTREAM).around(ADS).around(ENVOY);
+
+  @Test
+  public void validateTestRequestToEchoServerViaEnvoy() throws InterruptedException {
+    assertThat(onStreamCloseWithErrorLatch.await(15, TimeUnit.SECONDS))
+        .isTrue()
+        .overridingErrorMessage("failed to close ADS stream");
+
+    assertThat(onStreamOpenLatch.await(15, TimeUnit.SECONDS))
+        .isTrue()
+        .overridingErrorMessage("failed to open ADS stream");
+
+    assertThat(onStreamRequestLatch.await(15, TimeUnit.SECONDS))
+        .isTrue()
+        .overridingErrorMessage("failed to receive ADS request");
+
+    assertThat(onStreamResponseLatch.await(15, TimeUnit.SECONDS))
+        .isTrue()
+        .overridingErrorMessage("failed to send ADS response");
+
+    String baseUri =
+        String.format(
+            "http://%s:%d", ENVOY.getContainerIpAddress(), ENVOY.getMappedPort(LISTENER_PORT));
+
+    await()
+        .atMost(5, TimeUnit.SECONDS)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                given()
+                    .baseUri(baseUri)
+                    .contentType(ContentType.TEXT)
+                    .when()
+                    .get("/")
+                    .then()
+                    .statusCode(200)
+                    .and()
+                    .body(containsString(UPSTREAM.response)));
+  }
+}

--- a/server/src/test/java/io/envoyproxy/controlplane/server/V3OnlyDiscoveryServerCallbacks.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/V3OnlyDiscoveryServerCallbacks.java
@@ -1,5 +1,6 @@
 package io.envoyproxy.controlplane.server;
 
+import io.envoyproxy.controlplane.server.exception.RequestException;
 import io.envoyproxy.envoy.service.discovery.v3.DeltaDiscoveryRequest;
 import io.envoyproxy.envoy.service.discovery.v3.DiscoveryRequest;
 import io.envoyproxy.envoy.service.discovery.v3.DiscoveryResponse;
@@ -26,18 +27,18 @@ public class V3OnlyDiscoveryServerCallbacks implements DiscoveryServerCallbacks 
   }
 
   @Override
-  public void onStreamOpen(long streamId, String typeUrl) {
+  public void onStreamOpen(long streamId, String typeUrl) throws RequestException {
     onStreamOpenLatch.countDown();
   }
 
   @Override
-  public void onV3StreamRequest(long streamId, DiscoveryRequest request) {
+  public void onV3StreamRequest(long streamId, DiscoveryRequest request) throws RequestException {
     onStreamRequestLatch.countDown();
   }
 
   @Override
   public void onV3StreamDeltaRequest(long streamId,
-                                     DeltaDiscoveryRequest request) {
+                                     DeltaDiscoveryRequest request) throws RequestException {
     throw new IllegalStateException("Unexpected delta request");
   }
 


### PR DESCRIPTION
This PR introduces throwing a checked exception from stream callbacks, and catching them to trigger clean up tasks such as calling onStreamClose(WithError)

This follows a similar pattern to the go-control-plane where certain callbacks can return errors https://github.com/envoyproxy/go-control-plane/blob/bf9fc1db9d0fefb8df1291fc4638b0f2d7f39a7e/pkg/server/v3/server.go#L70-L81

And a defer statement calls OnStreamClosed
https://github.com/envoyproxy/go-control-plane/blob/bf9fc1db9d0fefb8df1291fc4638b0f2d7f39a7e/pkg/server/sotw/v3/server.go#L93-L98

Signed-off-by: Shulin Jia <shulin@squareup.com>