### PR TITLE
Update pom.xml | Bump up JUnit 4 version to latest stable version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <checkstyle.version>8.18</checkstyle.version>
         <grpc.version>1.48.1</grpc.version>
         <guava.version>31.1-android</guava.version><!-- Keep the Guava version in sync with grpc-java -->
-        <junit.version>4.13.1</junit.version>
+        <junit.version>4.13.2</junit.version>
         <protobuf.version>3.21.5</protobuf.version><!-- Keep the Protobuf version in sync with grpc-java -->
         <rest-assured.version>3.1.0</rest-assured.version>
         <slf4j.version>1.7.26</slf4j.version>


### PR DESCRIPTION
Upgrading the JUnit 4 version from 4.13.1 to 4.13.2 (Latest and Stable version for JUnit4).

Signed-off-by: Siddhant Chadha <academycodex@gmail.com>