### PR TITLE
Update integration tests to use `host.testcontainers.internal`

### DIFF
--- a/server/src/test/java/io/envoyproxy/controlplane/server/EnvoyContainer.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/EnvoyContainer.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
@@ -36,11 +37,11 @@ class EnvoyContainer extends GenericContainer<EnvoyContainer> {
     withClasspathResourceMapping(LAUNCH_ENVOY_SCRIPT, LAUNCH_ENVOY_SCRIPT_DEST, BindMode.READ_ONLY);
     withClasspathResourceMapping(config, CONFIG_DEST, BindMode.READ_ONLY);
 
-    withExtraHost("host.docker.internal","host-gateway");
-
+    final Integer controlPlanePort = controlPlanePortSupplier.get();
+    Testcontainers.exposeHostPorts(controlPlanePort);
     withCommand(
         "/bin/bash", "/usr/local/bin/launch_envoy.sh",
-        Integer.toString(controlPlanePortSupplier.get()),
+        Integer.toString(controlPlanePort),
         CONFIG_DEST,
         "-l", "debug"
     );

--- a/server/src/test/resources/envoy/ads.v3.config.yaml
+++ b/server/src/test/resources/envoy/ads.v3.config.yaml
@@ -29,7 +29,7 @@ static_resources:
           - endpoint:
               address:
                 socket_address:
-                  address: host.docker.internal
+                  address: host.testcontainers.internal
                   port_value: HOST_PORT
     http2_protocol_options: {}
     name: ads_cluster

--- a/server/src/test/resources/envoy/ads.v3.delta.config.yaml
+++ b/server/src/test/resources/envoy/ads.v3.delta.config.yaml
@@ -29,7 +29,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: host.docker.internal
+                      address: host.testcontainers.internal
                       port_value: HOST_PORT
       http2_protocol_options: {}
       name: ads_cluster

--- a/server/src/test/resources/envoy/xds.v3.config.yaml
+++ b/server/src/test/resources/envoy/xds.v3.config.yaml
@@ -33,7 +33,7 @@ static_resources:
             - endpoint:
                 address:
                   socket_address:
-                    address: host.docker.internal
+                    address: host.testcontainers.internal
                     port_value: HOST_PORT
     http2_protocol_options: {}
     name: xds_cluster

--- a/server/src/test/resources/envoy/xds.v3.delta.config.yaml
+++ b/server/src/test/resources/envoy/xds.v3.delta.config.yaml
@@ -33,7 +33,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: host.docker.internal
+                      address: host.testcontainers.internal
                       port_value: HOST_PORT
       http2_protocol_options: {}
       name: xds_cluster


### PR DESCRIPTION
Motivation
While I was running the integration test, I found out that `host.docker.internal` doesn't work correctly on Linux. (It worked on Mac and Windows.) `host.docker.internal` is used for the container to access the host but the DNS resolution was keeping failing. While I was debugging on it, I also found out that the Testcontainers provides `host.testcontainers.internal` for the same purpose and there's no reason not to use it. https://java.testcontainers.org/features/networking/

Modification
- Use `host.testcontainers.internal` instead of `host.docker.internal`

Result
- The integration tests now run successfully on Linux.