### PR TITLE
Fix failure for update_protobuf workflow

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -13,6 +13,8 @@ jobs:
     uses: ./.github/workflows/compare-envoy-versions.yml
 
   call-update-protobuf:
+    permissions:
+      pull-requests: write
     needs: call-compare-envoy-versions-workflow
     if: ${{ needs.call-compare-envoy-versions-workflow.outputs.target-version != 'noop' }}
     uses: ./.github/workflows/update-protobuf.yml

--- a/.github/workflows/update-protobuf.yml
+++ b/.github/workflows/update-protobuf.yml
@@ -14,7 +14,6 @@ on:
 jobs:
   update-protobuf:
     permissions:
-      contents: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
After last week's changes to github workflows, the jobs scheduled to run
every day that check the latest available envoy version and update protobuf
files (if needed) are failing due incorrect permissions. This patch attempts
to fix this issue.
