### PR TITLE
Fix workflow failures

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -14,6 +14,7 @@ jobs:
 
   call-update-protobuf:
     permissions:
+      contents: read
       pull-requests: write
     needs: call-compare-envoy-versions-workflow
     if: ${{ needs.call-compare-envoy-versions-workflow.outputs.target-version != 'noop' }}

--- a/.github/workflows/update-protobuf.yml
+++ b/.github/workflows/update-protobuf.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   update-protobuf:
     permissions:
+      contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The `scheduled` workflow still fails with the following problem:

```
[Invalid workflow file: .github/workflows/scheduled.yml#L15](https://github.com/envoyproxy/java-control-plane/actions/runs/7500670890/workflow)
The workflow is not valid. .github/workflows/scheduled.yml (Line: 15, Col: 3): Error calling workflow 'envoyproxy/java-control-plane/.github/workflows/update-protobuf.yml@5286fba8899534d5aeda522dc06209a8cc57d2d3'. The workflow is requesting 'contents: read', but is only allowed 'contents: none'.
``` 

It seems that we need to explicitly set the `contents` scope, otherwise it will default to none.

cc @nezdolik @phlax 