### PR TITLE
Fix update-protobuf workflow (we are getting closer =))

### DIFF
--- a/.github/workflows/update-protobuf.yml
+++ b/.github/workflows/update-protobuf.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   update-protobuf:
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The `update-protobuf` workflow is still failing due to lack of permissions 
on pushing a branch. We need to set `contents: write` permission according to the documentation here

https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#workflow-permissions