### PR TITLE
update permissions in caller workflow

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -14,7 +14,7 @@ jobs:
 
   call-update-protobuf:
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     needs: call-compare-envoy-versions-workflow
     if: ${{ needs.call-compare-envoy-versions-workflow.outputs.target-version != 'noop' }}


### PR DESCRIPTION
There are still failures in the automation that keeps the proto files
sync'd with envoy releases due insufficient permissions for scope
`content`