### PR TITLE
Add CEL Common Expression Language to scripts that grap protos

### DIFF
--- a/tools/update-api.sh
+++ b/tools/update-api.sh
@@ -64,4 +64,8 @@ curl -sL https://github.com/open-telemetry/opentelemetry-proto/archive/v${OPENTE
 mkdir -p "${protodir}/opentelemetry/proto"
 cp -r opentelemetry-proto-*/opentelemetry/proto/* "${protodir}/opentelemetry/proto"
 
+curl -sL https://github.com/google/cel-spec/archive/v${CEL_VERSION}.tar.gz | tar xz --wildcards '*.proto'
+mkdir -p "${protodir}/cel-spec"
+cp -r cel-spec-*/proto/* "${protodir}/cel-spec"
+
 popd >/dev/null

--- a/tools/update-sha.sh
+++ b/tools/update-sha.sh
@@ -8,13 +8,13 @@ set -o xtrace
 function find_sha() {
   local CONTENT=$1
   local DEPENDENCY=$2
-  echo "$CONTENT" | grep "$DEPENDENCY" -A 11 | grep -m 1 version | awk '{ print $3 }' | tr -d '"' | tr -d ","
+  echo "$CONTENT" | grep "$DEPENDENCY" -A 11 | grep -m 1 "version =" | awk '{ print $3 }' | tr -d '"' | tr -d ","
 }
 
 function find_date() {
   local CONTENT=$1
   local DEPENDENCY=$2
-  echo "$CONTENT" | grep "$DEPENDENCY" -A 11 | grep -m 1 release_date | awk '{ print $3 }' | tr -d '"' | tr -d ","
+  echo "$CONTENT" | grep "$DEPENDENCY" -A 11 | grep -m 1 "release_date =" | awk '{ print $3 }' | tr -d '"' | tr -d ","
 }
 
 function find_envoy_sha_from_tag() {
@@ -45,6 +45,9 @@ XDS_DATE=$(find_date "$CURL_OUTPUT" com_github_cncf_xds)
 OPENTELEMETRY_SHA=$(find_sha "$CURL_OUTPUT" opentelemetry_proto)
 OPENTELEMETRY_DATE=$(find_date "$CURL_OUTPUT" opentelemetry_proto)
 
+CEL_SHA=$(find_sha "$CURL_OUTPUT" dev_cel)
+CEL_DATE=$(find_date "$CURL_OUTPUT" dev_cel)
+
 echo -n "# Update the versions here and run update-api.sh
 
 # envoy (source: SHA from https://github.com/envoyproxy/envoy)
@@ -56,6 +59,7 @@ PGV_VERSION=\"$PGV_GIT_SHA\"  # $PGV_GIT_DATE
 PROMETHEUS_SHA=\"$PROMETHEUS_SHA\"  # $PROMETHEUS_DATE
 OPENCENSUS_VERSION=\"$OPENCENSUS_SHA\"  # $OPENCENSUS_DATE
 OPENTELEMETRY_VERSION=\"$OPENTELEMETRY_SHA\"  # $OPENTELEMETRY_DATE
+CEL_VERSION=\"$CEL_SHA\"  # $CEL_DATE
 XDS_SHA=\"$XDS_SHA\"  # $XDS_DATE
 "
 


### PR DESCRIPTION
Currently the automation that keeps API protos in sync with Envoy releases is broken due to this missing dependency