### PR TITLE
bug fix to requested resource does not exist handling

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/SimpleCache.java
@@ -377,10 +377,9 @@ public abstract class SimpleCache<T, U extends Snapshot> implements SnapshotCach
                   version);
             }
 
-            respond(watch, snapshot, group);
-
-            // Discard the watch. A new watch will be created for future snapshots once envoy ACKs the response.
-            return true;
+            // If we respond with an actual message, we can proceed to discard the watch. 
+            // A new watch will be created for future snapshots once envoy ACKs the response.
+            return respond(watch, snapshot, group);
           }
 
           // Do not discard the watch. The request version is the same as the snapshot version, so we wait to respond.


### PR DESCRIPTION
Bug fix to requested resource does not exist handling. We need to keep watch active for when resource is finally created so we can notify client.

This is to match the [xDS spec](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#knowing-when-a-requested-resource-does-not-exist) for how to handle the "resource does not exist" scenario.

Open issue: https://github.com/envoyproxy/java-control-plane/issues/219