### PR TITLE
switch to user token to authenticate against Sonatype server

### DIFF
--- a/.circleci/settings-snapshots.xml
+++ b/.circleci/settings-snapshots.xml
@@ -3,8 +3,8 @@
     <servers>
         <server>
             <id>sonatype-nexus-snapshots</id>
-            <username>${env.SONATYPE_USER}</username>
-            <password>${env.SONATYPE_PASSWORD}</password>
+            <username>${env.SONATYPE_TOKEN_USERNAME}</username>
+            <password>${env.SONATYPE_TOKEN_PASSWORD}</password>
         </server>
     </servers>
     <profiles>

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -3,13 +3,13 @@
     <servers>
         <server>
             <id>sonatype-nexus-snapshots</id>
-            <username>${env.SONATYPE_USER}</username>
-            <password>${env.SONATYPE_PASSWORD}</password>
+            <username>${env.SONATYPE_TOKEN_USERNAME}</username>
+            <password>${env.SONATYPE_TOKEN_PASSWORD}</password>
         </server>
         <server>
             <id>sonatype-nexus-staging</id>
-            <username>${env.SONATYPE_USER}</username>
-            <password>${env.SONATYPE_PASSWORD}</password>
+            <username>${env.SONATYPE_TOKEN_USERNAME}</username>
+            <password>${env.SONATYPE_TOKEN_PASSWORD}</password>
         </server>
     </servers>
     <profiles>


### PR DESCRIPTION
Token was generated as per instructions ->https://central.sonatype.org/publish/generate-token/

New env variables were added to the project settings in CircleCI so that they can be used by builds.