### PR TITLE
Add LinearCache and MuxCache for O(1) per-resource updates

### DIFF
--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/LinearCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/LinearCache.java
@@ -1,0 +1,681 @@
+package io.envoyproxy.controlplane.cache;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import com.google.protobuf.Message;
+import io.envoyproxy.controlplane.cache.Resources.ResourceType;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@code LinearCache} is a {@link Cache} for a single resource type (one {@code typeUrl}) backed by a flat
+ * {@code Map<name, resource>}. Unlike {@link SimpleCache}, mutating one resource is O(1): it touches a single
+ * map entry, bumps the cache version, and notifies <em>only the watches subscribed to the changed resource</em>
+ * (plus wildcard watches) — there is no full-collection rebuild or diff. This mirrors go-control-plane's
+ * {@code LinearCache} and is intended to be combined per-typeUrl via {@link MuxCache} (e.g. RDS/SDS on
+ * {@code LinearCache} for O(1) domain add/remove and certificate rotation, CDS/LDS on {@link SimpleCache}).
+ *
+ * <p>The cache is node-agnostic: a single shared collection serves the whole fleet of proxies, so there is no
+ * {@link NodeGroup} hashing. All watch bookkeeping is bucketed under a single, fixed {@code group} identity so
+ * that {@link #groups()} / {@link #statusInfo(Object)} and {@link MuxCache} aggregation behave consistently.
+ *
+ * <p><b>Lazy serialization.</b> Each resource's strong content-hash version
+ * ({@link VersionedResource#contentHash(Message)}, which marshals the resource) is computed on first use and
+ * memoized, mirroring go-control-plane's {@code cached_resource}. A resource that is never sent to nor compared
+ * for any watch is never marshaled — important when each proxy subscribes to only a few of many resources
+ * (e.g. one TLS secret per SNI out of 50k).
+ */
+@ThreadSafe
+public class LinearCache<T> implements Cache<T> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(LinearCache.class);
+
+  private final ResourceType resourceType;
+  private final T group;
+  private final String versionPrefix;
+
+  private final ReadWriteLock lock = new ReentrantReadWriteLock();
+  private final Lock readLock = lock.readLock();
+  private final Lock writeLock = lock.writeLock();
+
+  @GuardedBy("lock")
+  private final Map<String, CachedResource> resources = new HashMap<>();
+  @GuardedBy("lock")
+  private long version = 0;
+
+  private final CacheStatusInfoAggregator<T> statuses = new CacheStatusInfoAggregator<>();
+  private final AtomicLong watchCount = new AtomicLong();
+
+  /**
+   * Constructs a linear cache for the given resource type.
+   *
+   * @param resourceType the single resource type served by this cache
+   * @param group        the fixed group identity all watches are bucketed under (e.g. {@code "group"})
+   */
+  public LinearCache(ResourceType resourceType, T group) {
+    this(resourceType, group, "");
+  }
+
+  /**
+   * Constructs a linear cache for the given resource type.
+   *
+   * @param resourceType  the single resource type served by this cache
+   * @param group         the fixed group identity all watches are bucketed under
+   * @param versionPrefix prefix applied to the (wildcard/sotw) cache version, useful to distinguish
+   *                      replicated cache instances so a client re-connecting to another instance does not
+   *                      observe a stale-looking version. May be empty.
+   */
+  public LinearCache(ResourceType resourceType, T group, String versionPrefix) {
+    this.resourceType = Preconditions.checkNotNull(resourceType, "resourceType");
+    this.group = Preconditions.checkNotNull(group, "group");
+    this.versionPrefix = versionPrefix == null ? "" : versionPrefix;
+  }
+
+  // =========================================================================================
+  // Mutation API (O(1) per resource). Mirrors go-control-plane LinearCache.
+  // =========================================================================================
+
+  /**
+   * Creates or replaces a single resource and notifies only the watches that subscribe to it (and wildcard
+   * watches). O(1) with respect to the total number of resources in the cache. This is the operation used for
+   * TLS certificate rotation: same secret name, new content.
+   *
+   * @param name     the resource name
+   * @param resource the resource message
+   */
+  public void updateResource(String name, Message resource) {
+    Preconditions.checkNotNull(name, "name");
+    Preconditions.checkNotNull(resource, "resource");
+    writeLock.lock();
+    try {
+      version++;
+      resources.put(name, new CachedResource(resource));
+      notifyChanged(Collections.singleton(name));
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  /**
+   * Removes a single resource and notifies only the watches that subscribe to it (and wildcard watches).
+   *
+   * @param name the resource name to remove
+   */
+  public void deleteResource(String name) {
+    Preconditions.checkNotNull(name, "name");
+    writeLock.lock();
+    try {
+      version++;
+      resources.remove(name);
+      notifyChanged(Collections.singleton(name));
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  /**
+   * Applies a batch of updates and deletes atomically, notifying impacted watches once. More efficient than
+   * looping over {@link #updateResource} / {@link #deleteResource} under delta/wildcard watches.
+   *
+   * @param toUpdate resources to create or replace, keyed by name
+   * @param toDelete resource names to remove
+   */
+  public void updateResources(Map<String, ? extends Message> toUpdate, Collection<String> toDelete) {
+    Map<String, ? extends Message> updates = toUpdate == null ? Collections.emptyMap() : toUpdate;
+    Collection<String> deletes = toDelete == null ? Collections.emptyList() : toDelete;
+    writeLock.lock();
+    try {
+      version++;
+      Set<String> modified = new HashSet<>(updates.size() + deletes.size());
+      for (Map.Entry<String, ? extends Message> entry : updates.entrySet()) {
+        resources.put(entry.getKey(), new CachedResource(entry.getValue()));
+        modified.add(entry.getKey());
+      }
+      for (String name : deletes) {
+        resources.remove(name);
+        modified.add(name);
+      }
+      notifyChanged(modified);
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  /**
+   * Replaces the entire resource set. Every passed resource is treated as changed (no proto equality check),
+   * and any name absent from {@code newResources} is removed. When most resources are unchanged, prefer
+   * {@link #updateResources} which is far cheaper.
+   *
+   * @param newResources the new full set of resources, keyed by name
+   */
+  public void setResources(Map<String, ? extends Message> newResources) {
+    Map<String, ? extends Message> next = newResources == null ? Collections.emptyMap() : newResources;
+    writeLock.lock();
+    try {
+      version++;
+      Set<String> modified = new HashSet<>();
+      // Removed resources.
+      for (String name : new ArrayList<>(resources.keySet())) {
+        if (!next.containsKey(name)) {
+          resources.remove(name);
+          modified.add(name);
+        }
+      }
+      // Assume all passed resources changed.
+      for (Map.Entry<String, ? extends Message> entry : next.entrySet()) {
+        resources.put(entry.getKey(), new CachedResource(entry.getValue()));
+        modified.add(entry.getKey());
+      }
+      notifyChanged(modified);
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  // =========================================================================================
+  // Read accessors (diagnostics). Mirror go-control-plane GetResources / NumResources / NumWatches.
+  // =========================================================================================
+
+  /**
+   * Returns an immutable copy of the current resources keyed by name. Does not force the lazy version
+   * computation. Mirrors go-control-plane's {@code GetResources}.
+   */
+  public Map<String, Message> getResources() {
+    readLock.lock();
+    try {
+      Map<String, Message> out = new HashMap<>(resources.size());
+      resources.forEach((name, cached) -> out.put(name, cached.resource()));
+      return ImmutableMap.copyOf(out);
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  /**
+   * Returns the number of resources currently in the cache. Mirrors go-control-plane's {@code NumResources}.
+   */
+  public int numResources() {
+    readLock.lock();
+    try {
+      return resources.size();
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  /**
+   * Returns the total number of open watches (sotw + delta) tracked by this cache. Mirrors the spirit of
+   * go-control-plane's {@code NumWatches} family.
+   */
+  public int numWatches() {
+    StatusInfo<T> info = statusInfo(group);
+    return info == null ? 0 : info.numWatches();
+  }
+
+  /**
+   * Returns an immutable snapshot of the current resource names. Mostly for tests/diagnostics.
+   */
+  public Set<String> resourceNames() {
+    readLock.lock();
+    try {
+      return ImmutableSet.copyOf(resources.keySet());
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  // =========================================================================================
+  // Notification (runs under writeLock, mirroring go-control-plane which notifies under cache.mu.Lock()).
+  // Cost is O(numWatches x numModified), independent of the total resource count.
+  // =========================================================================================
+
+  @GuardedBy("lock")
+  private void notifyChanged(Set<String> modified) {
+    String cacheVersion = getVersion();
+
+    // SOTW watches.
+    CacheStatusInfo<T> status = statuses.getStatus(group).get(resourceType);
+    if (status != null) {
+      status.watchesRemoveIf((id, watch) -> {
+        List<String> names = watch.request().getResourceNamesList();
+        boolean wildcard = names.isEmpty();
+        if (!wildcard && names.stream().noneMatch(modified::contains)) {
+          // This watch does not care about any of the modified resources.
+          return false;
+        }
+        String newVersion = versionForNames(names);
+        if (watch.request().getVersionInfo().equals(newVersion)) {
+          // The resources this watch tracks did not actually change (e.g. same-content update). Keep it open
+          // rather than resending a duplicate at an identical version.
+          return false;
+        }
+        return respond(watch, newVersion);
+      });
+    }
+
+    // Delta watches.
+    DeltaCacheStatusInfo<T> deltaStatus = statuses.getDeltaStatus(group).get(resourceType);
+    if (deltaStatus != null) {
+      deltaStatus.watchesRemoveIf((id, watch) -> {
+        Map<String, CachedResource> changed = new HashMap<>();
+        List<String> removed = new ArrayList<>();
+        collectDeltaChanges(watch, modified, changed, removed);
+        if (changed.isEmpty() && removed.isEmpty()) {
+          return false;
+        }
+        ResponseState state = respondDelta(watch, changed, removed, cacheVersion, group);
+        return state.isFinished();
+      });
+    }
+  }
+
+  /**
+   * Computes, restricted to the {@code modified} set, which resources a delta watch should be sent as changed
+   * vs removed. Mirrors {@link SimpleCache}'s findChangedResources/findRemovedResources but scoped to the
+   * modified names so the cost stays O(numModified), not O(numResources).
+   */
+  @GuardedBy("lock")
+  private void collectDeltaChanges(DeltaWatch watch,
+                                   Set<String> modified,
+                                   Map<String, CachedResource> changed,
+                                   List<String> removed) {
+    for (String name : modified) {
+      CachedResource cached = resources.get(name);
+      if (cached == null) {
+        // Removed from the cache. Only report if the client tracks it.
+        if (watch.trackedResources().containsKey(name)) {
+          removed.add(name);
+        }
+        continue;
+      }
+      boolean include;
+      if (watch.pendingResources().contains(name)) {
+        include = true;
+      } else {
+        String trackedVersion = watch.trackedResources().get(name);
+        if (trackedVersion == null) {
+          // Not tracked by the client: only send under wildcard subscriptions.
+          include = watch.isWildcard();
+        } else {
+          include = !cached.version().equals(trackedVersion);
+        }
+      }
+      if (include) {
+        changed.put(name, cached);
+      }
+    }
+  }
+
+  // =========================================================================================
+  // SOTW watch creation (ported from SimpleCache, operating on the flat resource map).
+  // =========================================================================================
+
+  @Override
+  public Watch createWatch(
+      boolean ads,
+      XdsRequest request,
+      Set<String> knownResourceNames,
+      Consumer<Response> responseConsumer,
+      boolean hasClusterChanged,
+      boolean allowDefaultEmptyEdsUpdate) {
+    ResourceType requestResourceType = request.getResourceType();
+    Preconditions.checkNotNull(requestResourceType, "unsupported type URL %s", request.getTypeUrl());
+    Preconditions.checkArgument(requestResourceType.equals(resourceType),
+        "request type %s does not match cache type %s", requestResourceType, resourceType);
+
+    readLock.lock();
+    try {
+      CacheStatusInfo<T> status = statuses.getOrAddStatusInfo(group, requestResourceType);
+      status.setLastWatchRequestTime(System.currentTimeMillis());
+
+      String version = versionForNames(request.getResourceNamesList());
+
+      Watch watch = new Watch(ads, allowDefaultEmptyEdsUpdate, request, responseConsumer);
+
+      Set<String> requestedResources = ImmutableSet.copyOf(request.getResourceNamesList());
+
+      // If the request asks for resources we have not sent yet, respond immediately when we have them.
+      if (!knownResourceNames.equals(requestedResources)) {
+        Sets.SetView<String> newResourceHints = Sets.difference(requestedResources, knownResourceNames);
+        if (resources.keySet().stream().anyMatch(newResourceHints::contains)) {
+          respond(watch, version);
+          return watch;
+        }
+      } else if (hasClusterChanged && requestResourceType.equals(ResourceType.ENDPOINT)) {
+        respond(watch, version);
+        return watch;
+      }
+
+      // If the requester is already up-to-date, leave an open watch.
+      if (request.getVersionInfo().equals(version)) {
+        openWatch(status, watch, request.getTypeUrl(), request.getResourceNamesList(), request.getVersionInfo());
+        return watch;
+      }
+
+      // Otherwise respond immediately; if the response was withheld (ADS, missing names), leave an open watch.
+      boolean responded = respond(watch, version);
+      if (!responded) {
+        openWatch(status, watch, request.getTypeUrl(), request.getResourceNamesList(), request.getVersionInfo());
+      }
+      return watch;
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  // =========================================================================================
+  // Delta watch creation (ported from SimpleCache, operating on the flat resource map).
+  // =========================================================================================
+
+  @Override
+  public DeltaWatch createDeltaWatch(
+      DeltaXdsRequest request,
+      String requesterVersion,
+      Map<String, String> resourceVersions,
+      Set<String> pendingResources,
+      boolean isWildcard,
+      Consumer<DeltaResponse> responseConsumer,
+      boolean hasClusterChanged) {
+    ResourceType requestResourceType = request.getResourceType();
+    Preconditions.checkNotNull(requestResourceType, "unsupported type URL %s", request.getTypeUrl());
+    Preconditions.checkArgument(requestResourceType.equals(resourceType),
+        "request type %s does not match cache type %s", requestResourceType, resourceType);
+
+    readLock.lock();
+    try {
+      DeltaCacheStatusInfo<T> status = statuses.getOrAddDeltaStatusInfo(group, requestResourceType);
+      status.setLastWatchRequestTime(System.currentTimeMillis());
+
+      String version = getVersion();
+
+      DeltaWatch watch = new DeltaWatch(request,
+          ImmutableMap.copyOf(resourceVersions),
+          ImmutableSet.copyOf(pendingResources),
+          requesterVersion,
+          isWildcard,
+          responseConsumer);
+
+      // If the requester is up-to-date with the cache version, we may still owe pending resources.
+      if (version.equals(requesterVersion)) {
+        if (!isWildcard && !watch.pendingResources().isEmpty()) {
+          Map<String, CachedResource> requestedResources = watch.pendingResources()
+              .stream()
+              .filter(resources::containsKey)
+              .collect(Collectors.toMap(Function.identity(), resources::get));
+          ResponseState state = respondDelta(watch, requestedResources, Collections.emptyList(), version, group);
+          if (state.isFinished()) {
+            return watch;
+          }
+        } else if (hasClusterChanged && requestResourceType.equals(ResourceType.ENDPOINT)) {
+          ResponseState state = respondDelta(watch, version, group);
+          if (state.isFinished()) {
+            return watch;
+          }
+        }
+        openWatch(status, watch, request.getTypeUrl(), watch.trackedResources().keySet(), requesterVersion);
+        return watch;
+      }
+
+      // Version differs: respond with the diff between what the client tracks and the current cache.
+      ResponseState state = respondDelta(watch, version, group);
+      if (state.isFinished()) {
+        return watch;
+      }
+      openWatch(status, watch, request.getTypeUrl(), watch.trackedResources().keySet(), requesterVersion);
+      return watch;
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  private <V extends AbstractWatch<?, ?>> void openWatch(MutableStatusInfo<T, V> status,
+                                                         V watch,
+                                                         String url,
+                                                         Collection<String> resourceNames,
+                                                         String version) {
+    long watchId = watchCount.incrementAndGet();
+    status.setWatch(watchId, watch);
+    watch.setStop(() -> status.removeWatch(watchId));
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("open watch {} for {}[{}] in group {} for version {}",
+          watchId, url, String.join(", ", resourceNames), group, version);
+    }
+  }
+
+  // =========================================================================================
+  // Response building (ported from SimpleCache).
+  // =========================================================================================
+
+  @GuardedBy("lock")
+  private boolean respond(Watch watch, String version) {
+    boolean allowDefaultResource = false;
+    if (!watch.request().getResourceNamesList().isEmpty() && watch.ads()) {
+      Collection<String> missingNames = watch.request().getResourceNamesList().stream()
+          .filter(name -> !resources.containsKey(name))
+          .collect(Collectors.toList());
+
+      if (!missingNames.isEmpty()) {
+        if (watch.allowDefaultEmptyEdsUpdate() && watch.request().getResourceType().equals(ResourceType.ENDPOINT)) {
+          allowDefaultResource = true;
+        } else {
+          LOGGER.info(
+              "not responding in ADS mode for {} in group {} at version {} for request [{}] since [{}] not in cache",
+              watch.request().getTypeUrl(), group, version,
+              String.join(", ", watch.request().getResourceNamesList()),
+              String.join(", ", missingNames));
+          return false;
+        }
+      }
+    }
+
+    Response response = createResponse(watch.request(), version, allowDefaultResource);
+    try {
+      watch.respond(response);
+      return true;
+    } catch (WatchCancelledException e) {
+      LOGGER.error("failed to respond for {} in group {} at version {} because watch was already cancelled",
+          watch.request().getTypeUrl(), group, version);
+    }
+    return false;
+  }
+
+  @GuardedBy("lock")
+  private Response createResponse(XdsRequest request, String version, boolean allowDefaultResource) {
+    Collection<Message> filtered;
+    if (request.getResourceNamesList().isEmpty()) {
+      filtered = resources.values().stream().map(CachedResource::resource).collect(Collectors.toList());
+    } else {
+      filtered = request.getResourceNamesList().stream()
+          .map(name -> {
+            CachedResource cached = resources.get(name);
+            if (cached != null) {
+              return cached.resource();
+            }
+            return allowDefaultResource ? defaultResource(name, request.getResourceType()) : null;
+          })
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
+    }
+    return Response.create(request, filtered, version);
+  }
+
+  @GuardedBy("lock")
+  private ResponseState respondDelta(DeltaWatch watch, String version, T group) {
+    Map<String, CachedResource> changed = new HashMap<>();
+    List<String> removed = new ArrayList<>();
+    // Compare the full cache against what the client tracks/pends (used on the initial / version-mismatch path).
+    for (Map.Entry<String, CachedResource> entry : resources.entrySet()) {
+      String name = entry.getKey();
+      if (watch.pendingResources().contains(name)) {
+        changed.put(name, entry.getValue());
+      } else {
+        String trackedVersion = watch.trackedResources().get(name);
+        if (trackedVersion == null) {
+          if (watch.isWildcard()) {
+            changed.put(name, entry.getValue());
+          }
+        } else if (!entry.getValue().version().equals(trackedVersion)) {
+          changed.put(name, entry.getValue());
+        }
+      }
+    }
+    for (String name : watch.trackedResources().keySet()) {
+      if (!resources.containsKey(name)) {
+        removed.add(name);
+      }
+    }
+    return respondDelta(watch, changed, removed, version, group);
+  }
+
+  @GuardedBy("lock")
+  private ResponseState respondDelta(DeltaWatch watch,
+                                     Map<String, CachedResource> resourcesToSend,
+                                     List<String> removedResources,
+                                     String version,
+                                     T group) {
+    if (resourcesToSend.isEmpty() && removedResources.isEmpty()) {
+      return ResponseState.UNRESPONDED;
+    }
+    // Only the resources actually being sent get their (lazy) version computed and wrapped here.
+    Map<String, VersionedResource<?>> versioned = new HashMap<>(resourcesToSend.size());
+    resourcesToSend.forEach((name, cached) -> versioned.put(name, cached.toVersionedResource()));
+
+    DeltaResponse response = DeltaResponse.create(watch.request(), versioned, removedResources, version);
+    try {
+      watch.respond(response);
+      return ResponseState.RESPONDED;
+    } catch (WatchCancelledException e) {
+      LOGGER.error("failed to respond delta for {} in group {} with version {} because watch was already cancelled",
+          watch.request().getTypeUrl(), group, version);
+    }
+    return ResponseState.CANCELLED;
+  }
+
+  private Message defaultResource(String resourceName, ResourceType resourceType) {
+    if (resourceType.equals(ResourceType.ENDPOINT)) {
+      return ClusterLoadAssignment.newBuilder().setClusterName(resourceName).build();
+    }
+    throw new IllegalArgumentException(String.format("no default resource for resourceType: [%s]", resourceType));
+  }
+
+  // =========================================================================================
+  // Versioning.
+  // =========================================================================================
+
+  @GuardedBy("lock")
+  private String getVersion() {
+    return versionPrefix + version;
+  }
+
+  /**
+   * Computes the SOTW version for a specific set of requested resource names. For a wildcard request (empty
+   * names) this is the cache-global version (changes on any modification). For a named request it is a
+   * deterministic hash over just those resources' content versions, so a watch is only considered out-of-date
+   * when one of <em>its</em> resources actually changed — avoiding spurious pushes to unrelated watches.
+   */
+  @GuardedBy("lock")
+  private String versionForNames(Collection<String> names) {
+    if (names.isEmpty()) {
+      return getVersion();
+    }
+    Hasher hasher = Hashing.sha256().newHasher();
+    names.stream().sorted().forEach(name -> {
+      CachedResource cached = resources.get(name);
+      hasher.putString(name, StandardCharsets.UTF_8)
+          .putString("=", StandardCharsets.UTF_8)
+          .putString(cached == null ? "" : cached.version(), StandardCharsets.UTF_8)
+          .putString(";", StandardCharsets.UTF_8);
+    });
+    return hasher.hash().toString();
+  }
+
+  // =========================================================================================
+  // Cache<T>.
+  // =========================================================================================
+
+  @Override
+  public Collection<T> groups() {
+    return ImmutableSet.copyOf(statuses.groups());
+  }
+
+  @Override
+  public StatusInfo<T> statusInfo(T group) {
+    readLock.lock();
+    try {
+      Map<ResourceType, CacheStatusInfo<T>> statusMap = statuses.getStatus(group);
+      Map<ResourceType, DeltaCacheStatusInfo<T>> deltaStatusMap = statuses.getDeltaStatus(group);
+      if (statusMap.isEmpty() && deltaStatusMap.isEmpty()) {
+        return null;
+      }
+      List<StatusInfo<T>> collection = new ArrayList<>();
+      collection.addAll(statusMap.values());
+      collection.addAll(deltaStatusMap.values());
+      return new GroupCacheStatusInfo<>(collection);
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  /**
+   * A resource held in the cache whose strong content-hash version is computed lazily on first use and then
+   * memoized — mirroring go-control-plane's {@code cached_resource}. Resources never sent to or compared for a
+   * watch are therefore never marshaled.
+   */
+  private static final class CachedResource {
+    private final Message resource;
+    private final Supplier<String> version;
+
+    CachedResource(Message resource) {
+      this.resource = Preconditions.checkNotNull(resource, "resource");
+      this.version = Suppliers.memoize(() -> VersionedResource.contentHash(resource));
+    }
+
+    Message resource() {
+      return resource;
+    }
+
+    String version() {
+      return version.get();
+    }
+
+    VersionedResource<?> toVersionedResource() {
+      return VersionedResource.create(resource, version.get());
+    }
+  }
+
+  private enum ResponseState {
+    RESPONDED,
+    UNRESPONDED,
+    CANCELLED;
+
+    private boolean isFinished() {
+      return this.equals(RESPONDED) || this.equals(CANCELLED);
+    }
+  }
+}

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/MuxCache.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/MuxCache.java
@@ -1,0 +1,94 @@
+package io.envoyproxy.controlplane.cache;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.envoyproxy.controlplane.cache.Resources.ResourceType;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * {@code MuxCache} multiplexes across several {@link Cache} instances keyed by resource type, delegating each
+ * watch to the cache responsible for the requested {@code typeUrl}. This lets each resource type use the cache
+ * strategy that fits it — e.g. RDS/SDS on {@link LinearCache} for O(1) updates and certificate rotation, while
+ * CDS/LDS stay on {@link SimpleCache}. Mirrors go-control-plane's {@code MuxCache}.
+ *
+ * <p>If a request arrives for a type with no configured cache it is a configuration error and a
+ * {@link IllegalArgumentException} is raised (consistent with {@link SimpleCache} rejecting unsupported types).
+ */
+@ThreadSafe
+public class MuxCache<T> implements Cache<T> {
+
+  private final Map<ResourceType, Cache<T>> caches;
+
+  /**
+   * Constructs a mux cache.
+   *
+   * @param caches the per-resource-type caches to delegate to
+   */
+  public MuxCache(Map<ResourceType, Cache<T>> caches) {
+    this.caches = ImmutableMap.copyOf(caches);
+  }
+
+  @Override
+  public Watch createWatch(
+      boolean ads,
+      XdsRequest request,
+      Set<String> knownResourceNames,
+      Consumer<Response> responseConsumer,
+      boolean hasClusterChanged,
+      boolean allowDefaultEmptyEdsUpdate) {
+    return resolve(request.getResourceType(), request.getTypeUrl())
+        .createWatch(ads, request, knownResourceNames, responseConsumer, hasClusterChanged, allowDefaultEmptyEdsUpdate);
+  }
+
+  @Override
+  public DeltaWatch createDeltaWatch(
+      DeltaXdsRequest request,
+      String requesterVersion,
+      Map<String, String> resourceVersions,
+      Set<String> pendingResources,
+      boolean isWildcard,
+      Consumer<DeltaResponse> responseConsumer,
+      boolean hasClusterChanged) {
+    return resolve(request.getResourceType(), request.getTypeUrl())
+        .createDeltaWatch(request, requesterVersion, resourceVersions, pendingResources, isWildcard,
+            responseConsumer, hasClusterChanged);
+  }
+
+  private Cache<T> resolve(ResourceType resourceType, String typeUrl) {
+    Cache<T> cache = resourceType == null ? null : caches.get(resourceType);
+    if (cache == null) {
+      throw new IllegalArgumentException(String.format("no cache configured for type URL %s", typeUrl));
+    }
+    return cache;
+  }
+
+  @Override
+  public Collection<T> groups() {
+    Set<T> groups = new java.util.HashSet<>();
+    for (Cache<T> cache : caches.values()) {
+      groups.addAll(cache.groups());
+    }
+    return ImmutableSet.copyOf(groups);
+  }
+
+  @Override
+  public StatusInfo<T> statusInfo(T group) {
+    List<StatusInfo<T>> infos = new ArrayList<>();
+    for (Cache<T> cache : caches.values()) {
+      StatusInfo<T> info = cache.statusInfo(group);
+      if (info != null) {
+        infos.add(info);
+      }
+    }
+    if (infos.isEmpty()) {
+      return null;
+    }
+    return new GroupCacheStatusInfo<>(infos);
+  }
+}

--- a/cache/src/main/java/io/envoyproxy/controlplane/cache/VersionedResource.java
+++ b/cache/src/main/java/io/envoyproxy/controlplane/cache/VersionedResource.java
@@ -39,6 +39,35 @@ public abstract class VersionedResource<T extends Message> {
     );
   }
 
+  /**
+   * Returns a new {@link VersionedResource} whose version is a strong content hash of the
+   * serialized protobuf bytes ({@code sha256(resource.toByteArray())}), mirroring go-control-plane's
+   * {@code HashResource}. Prefer this over {@link #create(Message)} when the version must reliably
+   * change whenever the resource content changes — most notably for TLS certificate (SDS) rotation,
+   * where a missed version change means Envoy silently keeps the old certificate. Unlike
+   * {@link #create(Message)} (whose distinguishing entropy is only the 32-bit {@code hashCode()}),
+   * this has full collision resistance. Used by {@code LinearCache}.
+   *
+   * @param resource the resource
+   * @param <T>      the type of resource
+   */
+  public static <T extends Message> VersionedResource<T> createWithContentHash(T resource) {
+    return create(resource, contentHash(resource));
+  }
+
+  /**
+   * Returns the strong content-hash version for a resource: {@code sha256(resource.toByteArray())}, mirroring
+   * go-control-plane's {@code HashResource}. This is the single source of truth for content-based versions; it
+   * marshals the resource, so callers that compute it lazily (e.g. {@code LinearCache}'s cached resources)
+   * should memoize the result.
+   *
+   * @param resource the resource
+   * @return the hex sha256 of the serialized resource
+   */
+  public static String contentHash(Message resource) {
+    return Hashing.sha256().hashBytes(resource.toByteArray()).toString();
+  }
+
   private static <T extends Message> String resourceHashCode(T resource) {
     return resource.getClass() + "@" + resource.hashCode();
   }

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/LinearCacheTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/LinearCacheTest.java
@@ -1,0 +1,293 @@
+package io.envoyproxy.controlplane.cache;
+
+import static io.envoyproxy.controlplane.cache.Resources.V3.SECRET_TYPE_URL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
+import com.google.protobuf.Message;
+import io.envoyproxy.controlplane.cache.Resources.ResourceType;
+import io.envoyproxy.envoy.config.core.v3.DataSource;
+import io.envoyproxy.envoy.config.core.v3.Node;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.Secret;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsCertificate;
+import io.envoyproxy.envoy.service.discovery.v3.DeltaDiscoveryRequest;
+import io.envoyproxy.envoy.service.discovery.v3.DiscoveryRequest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link LinearCache}, focused on the behaviors the fork relies on: O(1) targeted notification,
+ * delta named-subscription filtering, and content-hash versioning for TLS certificate rotation. Several cases
+ * are Java ports of go-control-plane's {@code linear_test.go} / {@code delta_test.go}.
+ */
+public class LinearCacheTest {
+
+  private static final String GROUP = "node";
+  private static final String R0 = "secret0";
+  private static final String R1 = "secret1";
+
+  private static Secret secret(String name, String value) {
+    return Secret.newBuilder()
+        .setName(name)
+        .setTlsCertificate(TlsCertificate.newBuilder()
+            .setCertificateChain(DataSource.newBuilder().setInlineString(value).build()))
+        .build();
+  }
+
+  private static String contentHash(Message message) {
+    return Hashing.sha256().hashBytes(message.toByteArray()).toString();
+  }
+
+  /**
+   * Collects a response's resources into a {@code List<Message>} so assertj varargs infer cleanly.
+   */
+  private static List<Message> resourcesOf(Response response) {
+    return new ArrayList<>(response.resources());
+  }
+
+  private static XdsRequest sotw(List<String> names, String version) {
+    DiscoveryRequest.Builder builder = DiscoveryRequest.newBuilder()
+        .setNode(Node.getDefaultInstance())
+        .setTypeUrl(SECRET_TYPE_URL)
+        .setVersionInfo(version);
+    names.forEach(builder::addResourceNames);
+    return XdsRequest.create(builder.build());
+  }
+
+  private static DeltaXdsRequest delta() {
+    return DeltaXdsRequest.create(DeltaDiscoveryRequest.newBuilder()
+        .setNode(Node.getDefaultInstance())
+        .setTypeUrl(SECRET_TYPE_URL)
+        .build());
+  }
+
+  private static LinearCache<String> newCache() {
+    return new LinearCache<>(ResourceType.SECRET, GROUP);
+  }
+
+  /**
+   * Opens a sotw watch that stays open (no immediate response) by first probing the current version, then
+   * issuing the real request at that version with matching known resource names.
+   */
+  private WatchAndTracker openSotw(LinearCache<String> cache, List<String> names) {
+    ResponseTracker probe = new ResponseTracker();
+    cache.createWatch(false, sotw(names, ""), Collections.emptySet(), probe, false, false);
+    String version = probe.responses.isEmpty() ? "" : probe.responses.getLast().version();
+
+    ResponseTracker tracker = new ResponseTracker();
+    Set<String> known = new HashSet<>(names);
+    Watch watch = cache.createWatch(false, sotw(names, version), known, tracker, false, false);
+    return new WatchAndTracker(watch, tracker);
+  }
+
+  @Test
+  public void sotwNamedWatchIsNotifiedOnlyForItsOwnResource() {
+    LinearCache<String> cache = newCache();
+    cache.updateResource(R0, secret(R0, "v0"));
+    cache.updateResource(R1, secret(R1, "v0"));
+
+    WatchAndTracker a = openSotw(cache, Collections.singletonList(R0));
+    WatchAndTracker b = openSotw(cache, Collections.singletonList(R1));
+    assertThat(a.tracker.responses).isEmpty();
+    assertThat(b.tracker.responses).isEmpty();
+
+    // Change only R0: only watch A must be notified.
+    cache.updateResource(R0, secret(R0, "v1"));
+
+    assertThat(a.tracker.responses).hasSize(1);
+    assertThat(b.tracker.responses).isEmpty();
+    assertThat(resourcesOf(a.tracker.responses.getFirst())).containsExactly(secret(R0, "v1"));
+  }
+
+  @Test
+  public void sotwWildcardWatchIsNotifiedOnAnyChange() {
+    LinearCache<String> cache = newCache();
+    cache.updateResource(R0, secret(R0, "v0"));
+
+    WatchAndTracker wildcard = openSotw(cache, Collections.emptyList());
+    assertThat(wildcard.tracker.responses).isEmpty();
+
+    cache.updateResource(R1, secret(R1, "v0"));
+
+    assertThat(wildcard.tracker.responses).hasSize(1);
+    assertThat(resourcesOf(wildcard.tracker.responses.getFirst()))
+        .containsExactlyInAnyOrder(secret(R0, "v0"), secret(R1, "v0"));
+  }
+
+  @Test
+  public void sotwSameContentUpdateDoesNotResend() {
+    LinearCache<String> cache = newCache();
+    cache.updateResource(R0, secret(R0, "v0"));
+
+    WatchAndTracker a = openSotw(cache, Collections.singletonList(R0));
+
+    // Re-set the same content: the names-scoped version is unchanged, so no duplicate response is sent.
+    cache.updateResource(R0, secret(R0, "v0"));
+
+    assertThat(a.tracker.responses).isEmpty();
+  }
+
+  @Test
+  public void sotwDeleteNotifiesWildcard() {
+    LinearCache<String> cache = newCache();
+    cache.updateResource(R0, secret(R0, "v0"));
+
+    WatchAndTracker wildcard = openSotw(cache, Collections.emptyList());
+
+    cache.deleteResource(R0);
+
+    assertThat(wildcard.tracker.responses).hasSize(1);
+    assertThat(wildcard.tracker.responses.getFirst().resources()).isEmpty();
+  }
+
+  @Test
+  public void certRotationChangesVersionAndContent() {
+    LinearCache<String> cache = newCache();
+    Secret before = secret(R0, "old-cert");
+    cache.updateResource(R0, before);
+
+    WatchAndTracker a = openSotw(cache, Collections.singletonList(R0));
+    final String openVersion = a.watch.request().getVersionInfo();
+
+    Secret after = secret(R0, "new-cert");
+    cache.updateResource(R0, after);
+
+    assertThat(a.tracker.responses).hasSize(1);
+    Response response = a.tracker.responses.getFirst();
+    assertThat(resourcesOf(response)).containsExactly(after);
+    // The response version must differ from what the watch was opened at — otherwise Envoy would keep the
+    // old certificate. The strong content hash guarantees this.
+    assertThat(response.version()).isNotEqualTo(openVersion);
+    assertThat(contentHash(after)).isNotEqualTo(contentHash(before));
+  }
+
+  // ---- Delta ----
+
+  @Test
+  public void deltaNonWildcardReturnsOnlySubscribedResource() {
+    LinearCache<String> cache = newCache();
+    cache.updateResource(R0, secret(R0, "v0"));
+    cache.updateResource(R1, secret(R1, "v0"));
+
+    DeltaResponseTracker tracker = new DeltaResponseTracker();
+    // requesterVersion "" (mismatch) drives the full-diff path; pending = {R0}, not wildcard.
+    cache.createDeltaWatch(delta(), "", Collections.emptyMap(),
+        new HashSet<>(Collections.singletonList(R0)), false, tracker, false);
+
+    assertThat(tracker.responses).hasSize(1);
+    DeltaResponse response = tracker.responses.getFirst();
+    assertThat(response.resources().keySet()).containsExactly(R0);
+    assertThat(response.removedResources()).isEmpty();
+  }
+
+  @Test
+  public void deltaUpdateNotifiesOnlyTrackingWatchAndCarriesNewVersionOnRotation() {
+    LinearCache<String> cache = newCache();
+    Secret r0v0 = secret(R0, "v0");
+    cache.updateResource(R0, r0v0);
+    cache.updateResource(R1, secret(R1, "v0"));
+
+    // Open a delta watch tracking only R0 at the current cache version (so it stays open).
+    DeltaResponseTracker tracker = new DeltaResponseTracker();
+    Map<String, String> tracked = ImmutableMap.of(R0, contentHash(r0v0));
+    cache.createDeltaWatch(delta(), cacheVersion(cache), tracked,
+        Collections.emptySet(), false, tracker, false);
+    assertThat(tracker.responses).isEmpty();
+
+    // Updating R1 (not tracked, not wildcard) must NOT notify this watch.
+    cache.updateResource(R1, secret(R1, "v1"));
+    assertThat(tracker.responses).isEmpty();
+
+    // Rotating R0 must notify, with the new content.
+    Secret r0v1 = secret(R0, "v1");
+    cache.updateResource(R0, r0v1);
+    assertThat(tracker.responses).hasSize(1);
+    assertThat(tracker.responses.getFirst().resources()).containsKey(R0);
+    assertThat(tracker.responses.getFirst().resources().get(R0).resource()).isEqualTo(r0v1);
+  }
+
+  @Test
+  public void deltaDeleteSendsRemoved() {
+    LinearCache<String> cache = newCache();
+    Secret r0v0 = secret(R0, "v0");
+    cache.updateResource(R0, r0v0);
+
+    DeltaResponseTracker tracker = new DeltaResponseTracker();
+    Map<String, String> tracked = ImmutableMap.of(R0, contentHash(r0v0));
+    cache.createDeltaWatch(delta(), cacheVersion(cache), tracked,
+        Collections.emptySet(), false, tracker, false);
+    assertThat(tracker.responses).isEmpty();
+
+    cache.deleteResource(R0);
+
+    assertThat(tracker.responses).hasSize(1);
+    assertThat(tracker.responses.getFirst().removedResources()).containsExactly(R0);
+  }
+
+  @Test
+  public void accessorsReflectCacheContents() {
+    LinearCache<String> cache = newCache();
+    assertThat(cache.numResources()).isZero();
+
+    Secret s0 = secret(R0, "v0");
+    Secret s1 = secret(R1, "v0");
+    cache.updateResource(R0, s0);
+    cache.updateResource(R1, s1);
+
+    assertThat(cache.numResources()).isEqualTo(2);
+    assertThat(cache.getResources()).containsOnlyKeys(R0, R1);
+    assertThat(cache.getResources().get(R0)).isEqualTo(s0);
+    assertThat(cache.resourceNames()).containsExactlyInAnyOrder(R0, R1);
+
+    cache.deleteResource(R0);
+    assertThat(cache.numResources()).isEqualTo(1);
+    assertThat(cache.getResources()).containsOnlyKeys(R1);
+  }
+
+  /** Helper to learn the current cache version string by probing a wildcard delta watch's open version. */
+  private static String cacheVersion(LinearCache<String> cache) {
+    // The wildcard sotw version equals the cache-global version; probe it.
+    ResponseTracker probe = new ResponseTracker();
+    cache.createWatch(false,
+        XdsRequest.create(DiscoveryRequest.newBuilder()
+            .setNode(Node.getDefaultInstance()).setTypeUrl(SECRET_TYPE_URL).setVersionInfo("").build()),
+        Collections.emptySet(), probe, false, false);
+    return probe.responses.isEmpty() ? "" : probe.responses.getLast().version();
+  }
+
+  static class ResponseTracker implements Consumer<Response> {
+    final LinkedList<Response> responses = new LinkedList<>();
+
+    @Override
+    public void accept(Response response) {
+      responses.add(response);
+    }
+  }
+
+  static class DeltaResponseTracker implements Consumer<DeltaResponse> {
+    final LinkedList<DeltaResponse> responses = new LinkedList<>();
+
+    @Override
+    public void accept(DeltaResponse response) {
+      responses.add(response);
+    }
+  }
+
+  static class WatchAndTracker {
+    final Watch watch;
+    final ResponseTracker tracker;
+
+    WatchAndTracker(Watch watch, ResponseTracker tracker) {
+      this.watch = watch;
+      this.tracker = tracker;
+    }
+  }
+}

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/MuxCacheTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/MuxCacheTest.java
@@ -1,0 +1,97 @@
+package io.envoyproxy.controlplane.cache;
+
+import static io.envoyproxy.controlplane.cache.Resources.V3.ENDPOINT_TYPE_URL;
+import static io.envoyproxy.controlplane.cache.Resources.V3.ROUTE_TYPE_URL;
+import static io.envoyproxy.controlplane.cache.Resources.V3.SECRET_TYPE_URL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Message;
+import io.envoyproxy.controlplane.cache.Resources.ResourceType;
+import io.envoyproxy.envoy.config.core.v3.Node;
+import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.Secret;
+import io.envoyproxy.envoy.service.discovery.v3.DiscoveryRequest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link MuxCache}: requests are routed to the cache registered for their resource type, and a
+ * request for an unconfigured type is rejected. Demonstrates the fork's intended layout (SDS/RDS on
+ * {@link LinearCache}).
+ */
+public class MuxCacheTest {
+
+  private static final String GROUP = "node";
+
+  private LinearCache<String> secretCache = new LinearCache<>(ResourceType.SECRET, GROUP);
+  private LinearCache<String> routeCache = new LinearCache<>(ResourceType.ROUTE, GROUP);
+
+  private MuxCache<String> mux = new MuxCache<>(ImmutableMap.of(
+      ResourceType.SECRET, secretCache,
+      ResourceType.ROUTE, routeCache));
+
+  private static XdsRequest wildcard(String typeUrl) {
+    return XdsRequest.create(DiscoveryRequest.newBuilder()
+        .setNode(Node.getDefaultInstance())
+        .setTypeUrl(typeUrl)
+        .build());
+  }
+
+  @Test
+  public void routesEachTypeToItsCache() {
+    Secret secret = Secret.newBuilder().setName("secret0").build();
+    RouteConfiguration route = RouteConfiguration.newBuilder().setName("route0").build();
+    secretCache.updateResource("secret0", secret);
+    routeCache.updateResource("route0", route);
+
+    ResponseTracker sdsTracker = new ResponseTracker();
+    mux.createWatch(false, wildcard(SECRET_TYPE_URL), Collections.emptySet(), sdsTracker, false, false);
+    assertThat(sdsTracker.responses).hasSize(1);
+    assertThat(resourcesOf(sdsTracker.responses.getFirst())).containsExactly(secret);
+
+    ResponseTracker rdsTracker = new ResponseTracker();
+    mux.createWatch(false, wildcard(ROUTE_TYPE_URL), Collections.emptySet(), rdsTracker, false, false);
+    assertThat(rdsTracker.responses).hasSize(1);
+    assertThat(resourcesOf(rdsTracker.responses.getFirst())).containsExactly(route);
+  }
+
+  @Test
+  public void rejectsUnconfiguredType() {
+    ResponseTracker tracker = new ResponseTracker();
+    assertThatThrownBy(() ->
+        mux.createWatch(false, wildcard(ENDPOINT_TYPE_URL), Collections.emptySet(), tracker, false, false))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void groupsAndStatusAggregateAcrossCaches() {
+    secretCache.updateResource("secret0", Secret.newBuilder().setName("secret0").build());
+    // Open watches on both sub-caches.
+    mux.createWatch(false, wildcard(SECRET_TYPE_URL), Collections.emptySet(), new ResponseTracker(), false, false);
+    mux.createWatch(false, wildcard(ROUTE_TYPE_URL), Collections.emptySet(), new ResponseTracker(), false, false);
+
+    assertThat(mux.groups()).contains(GROUP);
+    StatusInfo<String> info = mux.statusInfo(GROUP);
+    assertThat(info).isNotNull();
+    assertThat(info.numWatches()).isGreaterThanOrEqualTo(0);
+  }
+
+  private static List<Message> resourcesOf(Response response) {
+    return new ArrayList<>(response.resources());
+  }
+
+  static class ResponseTracker implements Consumer<Response> {
+    final LinkedList<Response> responses = new LinkedList<>();
+
+    @Override
+    public void accept(Response response) {
+      responses.add(response);
+    }
+  }
+}

--- a/cache/src/test/java/io/envoyproxy/controlplane/cache/VersionedResourceTest.java
+++ b/cache/src/test/java/io/envoyproxy/controlplane/cache/VersionedResourceTest.java
@@ -1,0 +1,51 @@
+package io.envoyproxy.controlplane.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.envoyproxy.envoy.config.core.v3.DataSource;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.Secret;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.TlsCertificate;
+import org.junit.Test;
+
+/**
+ * Tests for {@link VersionedResource#createWithContentHash(com.google.protobuf.Message)}, the strong
+ * content-hash version used by {@link LinearCache}. The key property — relied on for TLS certificate
+ * rotation — is that the version changes iff the resource content changes.
+ */
+public class VersionedResourceTest {
+
+  private static Secret secret(String name, String cert) {
+    return Secret.newBuilder()
+        .setName(name)
+        .setTlsCertificate(TlsCertificate.newBuilder()
+            .setCertificateChain(DataSource.newBuilder().setInlineString(cert).build()))
+        .build();
+  }
+
+  @Test
+  public void sameContentYieldsSameVersion() {
+    String v1 = VersionedResource.createWithContentHash(secret("s", "cert-a")).version();
+    String v2 = VersionedResource.createWithContentHash(secret("s", "cert-a")).version();
+    assertThat(v1).isEqualTo(v2);
+  }
+
+  @Test
+  public void differentContentYieldsDifferentVersion() {
+    // This is the certificate-rotation guarantee: new cert content => new version => Envoy refetches.
+    String oldCert = VersionedResource.createWithContentHash(secret("s", "old-cert")).version();
+    String newCert = VersionedResource.createWithContentHash(secret("s", "new-cert")).version();
+    assertThat(oldCert).isNotEqualTo(newCert);
+  }
+
+  @Test
+  public void versionIsSha256Hex() {
+    String version = VersionedResource.createWithContentHash(secret("s", "cert")).version();
+    assertThat(version).hasSize(64).matches("[0-9a-f]{64}");
+  }
+
+  @Test
+  public void preservesResource() {
+    Secret secret = secret("s", "cert");
+    assertThat(VersionedResource.createWithContentHash(secret).resource()).isEqualTo(secret);
+  }
+}

--- a/server/src/test/java/io/envoyproxy/controlplane/server/MuxLinearCacheXdsDeltaIT.java
+++ b/server/src/test/java/io/envoyproxy/controlplane/server/MuxLinearCacheXdsDeltaIT.java
@@ -1,0 +1,171 @@
+package io.envoyproxy.controlplane.server;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+
+import io.envoyproxy.controlplane.cache.Cache;
+import io.envoyproxy.controlplane.cache.LinearCache;
+import io.envoyproxy.controlplane.cache.MuxCache;
+import io.envoyproxy.controlplane.cache.Resources.ResourceType;
+import io.envoyproxy.controlplane.cache.Resources.V3;
+import io.envoyproxy.controlplane.cache.TestResources;
+import io.envoyproxy.controlplane.cache.v3.SimpleCache;
+import io.envoyproxy.controlplane.cache.v3.Snapshot;
+import io.envoyproxy.envoy.config.core.v3.HeaderValue;
+import io.envoyproxy.envoy.config.core.v3.HeaderValueOption;
+import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
+import io.grpc.netty.NettyServerBuilder;
+import io.restassured.http.ContentType;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+
+/**
+ * Real-Envoy integration test for the fork's new caches. The control plane is backed by a {@link MuxCache}
+ * that routes <b>RDS to a {@link LinearCache}</b> (the high-churn, O(1) side) and CDS/LDS/EDS/SDS to a
+ * {@link SimpleCache} — exactly the layout proposed in the fork design doc. A real Envoy (v1.37.2) connects
+ * over delta xDS, and we assert:
+ *
+ * <ol>
+ *   <li>Envoy boots, fetches the muxed config, and proxies an HTTP request to the upstream echo — proving
+ *       {@code MuxCache + LinearCache} can serve a real Envoy end-to-end.</li>
+ *   <li>A runtime {@code linearCache.updateResource("route0", ...)} (no snapshot rebuild) is applied by Envoy
+ *       on the live stream without reconnecting: Envoy ACKs a new RDS nonce, raises no NACK, and the new
+ *       route takes effect (a freshly added response header appears) — the end-to-end proof of O(1) dynamic
+ *       updates / certificate-rotation-style hot replacement.</li>
+ * </ol>
+ */
+public class MuxLinearCacheXdsDeltaIT {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MuxLinearCacheXdsDeltaIT.class);
+
+  private static final String CONFIG = "envoy/xds.v3.delta.config.yaml";
+  private static final String GROUP = "key";
+  private static final Integer LISTENER_PORT = 10000;
+  private static final String CLUSTER_NAME = "upstream";
+  private static final String ROUTE_NAME = "route0";
+  private static final String LISTENER_NAME = "listener0";
+
+  private static final CountDownLatch onStreamOpenLatch = new CountDownLatch(1);
+  private static final CountDownLatch onStreamRequestLatch = new CountDownLatch(1);
+
+  private static final ConcurrentHashMap<String, StringBuffer> resourceToNonceMap = new ConcurrentHashMap<>();
+  private static final StringBuffer nonce = new StringBuffer();
+  private static final StringBuffer errorDetails = new StringBuffer();
+
+  // CDS/LDS/EDS/SDS on SimpleCache (static side), RDS on LinearCache (high-churn side).
+  private static final SimpleCache<String> simpleCache = new SimpleCache<>(node -> GROUP);
+  private static final LinearCache<String> routeCache = new LinearCache<>(ResourceType.ROUTE, GROUP);
+
+  private static final EchoContainer UPSTREAM = new EchoContainer()
+      .withNetwork(Network.SHARED)
+      .withNetworkAliases("upstream");
+
+  private static final NettyGrpcServerRule XDS = new NettyGrpcServerRule() {
+    @Override
+    protected void configureServerBuilder(NettyServerBuilder builder) {
+      final DiscoveryServerCallbacks callbacks =
+          new V3DeltaDiscoveryServerCallbacks(onStreamOpenLatch, onStreamRequestLatch, nonce,
+              errorDetails, resourceToNonceMap);
+
+      // Full snapshot drives CDS/LDS (and carries a copy of the route to keep SimpleCache self-consistent),
+      // but Envoy fetches RDS from the LinearCache via the mux, so route changes go through updateResource().
+      Snapshot snapshot = V3TestSnapshots.createSnapshotNoEds(false, true, CLUSTER_NAME,
+          UPSTREAM.ipAddress(), EchoContainer.PORT, LISTENER_NAME, LISTENER_PORT, ROUTE_NAME, "1");
+      simpleCache.setSnapshot(GROUP, snapshot);
+      routeCache.updateResource(ROUTE_NAME, TestResources.createRoute(ROUTE_NAME, CLUSTER_NAME));
+
+      Map<ResourceType, Cache<String>> caches = new EnumMap<>(ResourceType.class);
+      caches.put(ResourceType.CLUSTER, simpleCache);
+      caches.put(ResourceType.LISTENER, simpleCache);
+      caches.put(ResourceType.ENDPOINT, simpleCache);
+      caches.put(ResourceType.SECRET, simpleCache);
+      caches.put(ResourceType.ROUTE, routeCache);
+      MuxCache<String> mux = new MuxCache<>(caches);
+
+      V3DiscoveryServer server = new V3DiscoveryServer(callbacks, mux);
+      builder.addService(server.getRouteDiscoveryServiceImpl());
+      builder.addService(server.getListenerDiscoveryServiceImpl());
+      builder.addService(server.getEndpointDiscoveryServiceImpl());
+      builder.addService(server.getClusterDiscoveryServiceImpl());
+      builder.addService(server.getSecretDiscoveryServiceImpl());
+    }
+  };
+
+  private static final EnvoyContainer ENVOY = new EnvoyContainer(CONFIG, () -> XDS.getServer().getPort())
+      .withExposedPorts(LISTENER_PORT)
+      .withNetwork(Network.SHARED);
+
+  @ClassRule
+  public static final RuleChain RULES = RuleChain.outerRule(UPSTREAM).around(XDS).around(ENVOY);
+
+  @Test
+  public void muxLinearCacheServesEnvoyAndAppliesRuntimeRouteUpdate() throws InterruptedException {
+    assertThat(onStreamOpenLatch.await(15, TimeUnit.SECONDS)).isTrue()
+        .overridingErrorMessage("failed to open xDS stream");
+    assertThat(onStreamRequestLatch.await(15, TimeUnit.SECONDS)).isTrue()
+        .overridingErrorMessage("failed to receive xDS request");
+
+    final String baseUri = String.format("http://%s:%d",
+        ENVOY.getContainerIpAddress(), ENVOY.getMappedPort(LISTENER_PORT));
+
+    // 1) MuxCache + LinearCache served a working config: Envoy proxies to the echo upstream.
+    await().atMost(10, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(
+        () -> given().baseUri(baseUri).contentType(ContentType.TEXT)
+            .when().get("/")
+            .then().statusCode(200)
+            .and().body(containsString(UPSTREAM.response)));
+
+    // The route was served by the LinearCache at its initial version (nonce "0"), with no NACK.
+    assertThat(errorDetails.toString()).isEqualTo("");
+    assertThat(resourceToNonceMap.get(V3.ROUTE_TYPE_URL).toString()).isEqualTo("0");
+    assertThat(resourceToNonceMap.get(V3.CLUSTER_TYPE_URL).toString()).isEqualTo("0");
+    assertThat(resourceToNonceMap.get(V3.LISTENER_TYPE_URL).toString()).isEqualTo("0");
+
+    // 2) Runtime O(1) update on the LinearCache: same route name, new content (adds a response header).
+    //    No snapshot rebuild, no reconnect — Envoy must apply it on the live stream.
+    RouteConfiguration updated = withResponseHeader(
+        TestResources.createRoute(ROUTE_NAME, CLUSTER_NAME), "x-xds4j", "linear-cache");
+    routeCache.updateResource(ROUTE_NAME, updated);
+
+    await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+      // Envoy ACK'd a new RDS version pushed by the LinearCache, and did not NACK.
+      assertThat(resourceToNonceMap.get(V3.ROUTE_TYPE_URL).toString()).isEqualTo("01");
+      assertThat(errorDetails.toString()).isEqualTo("");
+      // The new route is in effect: the added header is present and traffic still flows.
+      given().baseUri(baseUri).contentType(ContentType.TEXT)
+          .when().get("/")
+          .then().statusCode(200)
+          .and().header("x-xds4j", "linear-cache")
+          .and().body(containsString(UPSTREAM.response));
+    });
+    LOGGER.info("LinearCache runtime route update applied by Envoy without reconnect");
+  }
+
+  private static RouteConfiguration withResponseHeader(RouteConfiguration route, String key, String value) {
+    return route.toBuilder()
+        .setVirtualHosts(0, route.getVirtualHosts(0).toBuilder()
+            .addResponseHeadersToAdd(HeaderValueOption.newBuilder()
+                .setHeader(HeaderValue.newBuilder().setKey(key).setValue(value).build())
+                .build())
+            .build())
+        .build();
+  }
+
+  @AfterClass
+  public static void after() throws Exception {
+    ENVOY.close();
+    UPSTREAM.close();
+  }
+}


### PR DESCRIPTION
## Motivation

java-control-plane currently ships only `SimpleCache` (the `SnapshotCache` model), whereas go-control-plane also offers `LinearCache` and `MuxCache`. With `SimpleCache`, mutating a single resource requires rebuilding and diffing the **entire** snapshot on every `setSnapshot` — O(N) in the total resource count, regardless of how many resources actually changed. That is costly for deployments with many resources and frequent writes (e.g. a CDN front end with many domains and rolling TLS certificate rotation). This PR ports `LinearCache` + `MuxCache` to close that gap.

## What

- **`LinearCache<T>`** — a `Cache<T>` for a single `typeUrl`, backed by `Map<name, resource>`. `updateResource` / `deleteResource` / `updateResources` / `setResources` are O(1) and notify **only the watches subscribed to the changed resource** (plus wildcard watches), independent of total resource count. It reuses the existing `Watch` / `DeltaWatch` / `CacheStatusInfo` / `Response` / `DeltaResponse` machinery, so it is a drop-in for `V3DiscoveryServer` (which depends only on `ConfigWatcher`). Like go-control-plane's `LinearCache` it is node-agnostic — a single shared collection serves the whole fleet (no `NodeGroup` hashing). Adds `getResources` / `numResources` / `numWatches` / `resourceNames` accessors mirroring go-control-plane.
- **`MuxCache<T>`** — routes each watch to a per-type cache by `ResourceType`, so e.g. RDS/SDS can use `LinearCache` while CDS/LDS stay on `SimpleCache`.
- **Versioning** — `VersionedResource.contentHash()` = `sha256(toByteArray())`, mirroring go-control-plane's `HashResource`, as the single source of truth for content-based versions. The existing 32-bit `hashCode()`-based `create()` is left untouched (so `SimpleCache` behavior is unchanged). `LinearCache` computes per-resource versions **lazily** and memoizes them (`Suppliers.memoize`), mirroring go-control-plane's `cached_resource`: a resource never sent to or compared for any watch is never marshaled.

## Testing

- Cache unit tests: `LinearCacheTest`, `MuxCacheTest`, `VersionedResourceTest` (SOTW + delta: targeted notification, named-subscription filtering, wildcard, content-hash rotation, accessors).
- Real-Envoy integration test `MuxLinearCacheXdsDeltaIT`: boots Envoy v1.37.2 against a `MuxCache(SimpleCache → CDS/LDS/EDS/SDS, LinearCache → RDS)` control plane, verifies routing to an upstream, then applies a runtime `LinearCache.updateResource` and confirms Envoy applies it on the live stream **without reconnecting** (new response header appears, no NACK).
- Full suite green (`mvn test` + checkstyle), no regressions in existing `SimpleCache` tests.

## Notes / scope

To keep the change focused, a few go-control-plane `LinearCache` features are intentionally **not** included here and can follow up if there is interest: glob-collection / prefix subscriptions (`prefixWatches` / `SubscribedPrefixes`), resource TTL (`ResourceWithTTL`), and `MuxCache`'s arbitrary `Classify` function (this PR routes strictly by `ResourceType`). Happy to adjust API shape / naming to match maintainer preferences.