### PR TITLE
tools: fix update-sha.sh so the Envoy API auto-update job works again

### DIFF
--- a/tools/update-sha.sh
+++ b/tools/update-sha.sh
@@ -14,12 +14,12 @@ function find_sha() {
 function find_date() {
   local CONTENT=$1
   local DEPENDENCY=$2
-  echo "$CONTENT" | grep "$DEPENDENCY" -A 11 | grep -m 1 "release_date =" | awk '{ print $3 }' | tr -d '"' | tr -d ","
+  echo "$CONTENT" | grep "$DEPENDENCY" -A 11 | grep -m 1 "release_date =" | awk '{ print $3 }' | tr -d '"' | tr -d "," || true
 }
 
 function find_envoy_sha_from_tag() {
   local TAG=$1
-  curl -s https://api.github.com/repos/envoyproxy/envoy/tags | grep "$TAG" -A 4 | grep sha | awk '{print $2}' | tr -d '"' | tr -d ","
+  curl -s "https://api.github.com/repos/envoyproxy/envoy/commits/$TAG" | awk -F'"' '/"sha"/ && !found {print $4; found=1}'
 }
 
 CURRENT_ENVOY_RELEASE=$(cat envoy_release)
@@ -36,8 +36,8 @@ PGV_GIT_DATE=$(find_date "$CURL_OUTPUT" com_envoyproxy_protoc_gen_validate)
 PROMETHEUS_SHA=$(find_sha "$CURL_OUTPUT" prometheus_metrics_model)
 PROMETHEUS_DATE=$(find_date "$CURL_OUTPUT" prometheus_metrics_model)
 
-XDS_SHA=$(find_sha "$CURL_OUTPUT" com_github_cncf_xds)
-XDS_DATE=$(find_date "$CURL_OUTPUT" com_github_cncf_xds)
+XDS_SHA=$(find_sha "$CURL_OUTPUT" "xds = dict")
+XDS_DATE=$(find_date "$CURL_OUTPUT" "xds = dict")
 
 OPENTELEMETRY_SHA=$(find_sha "$CURL_OUTPUT" opentelemetry_proto)
 OPENTELEMETRY_DATE=$(find_date "$CURL_OUTPUT" opentelemetry_proto)


### PR DESCRIPTION
The Envoy API is stuck at v1.37.2 because the scheduled  update-protobuf job has been failing
on every run, for example:
https://github.com/envoyproxy/java-control-plane/actions/runs/27202007279/job/80308114011

The break is in tools/update-sha.sh:

- `release_date` was removed from repository_locations.bzl, so find_date aborts the
  script (under `set -e -o pipefail`) before API_SHAS is written → update-api.sh fails
  with `gzip: stdin: not in gzip format`.
- The cncf/xds dep was renamed com_github_cncf_xds → xds, leaving XDS_SHA empty.
- find_envoy_sha_from_tag only scanned page 1 of the /tags API.

Fix: tolerate the missing release_date, resolve the tag SHA via /commits/{ref}, and
look up the renamed xds dep.

Verified: `./update-sha.sh v1.38.1 | tee API_SHAS && ./update-api.sh` now bumps cleanly to v1.38.1.