### PR TITLE
tools: set version to 1.0.53-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java-control-plane</artifactId>
         <groupId>io.envoyproxy.controlplane</groupId>
-        <version>1.0.52</version>
+        <version>1.0.53-SNAPSHOT</version>
     </parent>
 
     <artifactId>api</artifactId>

--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java-control-plane</artifactId>
         <groupId>io.envoyproxy.controlplane</groupId>
-        <version>1.0.52</version>
+        <version>1.0.53-SNAPSHOT</version>
     </parent>
 
     <artifactId>cache</artifactId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>io.envoyproxy.controlplane</groupId>
             <artifactId>api</artifactId>
-            <version>1.0.52</version>
+            <version>1.0.53-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.envoyproxy.controlplane</groupId>
     <artifactId>java-control-plane</artifactId>
-    <version>1.0.52</version>
+    <version>1.0.53-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java-control-plane</artifactId>
         <groupId>io.envoyproxy.controlplane</groupId>
-        <version>1.0.52</version>
+        <version>1.0.53-SNAPSHOT</version>
     </parent>
 
     <artifactId>server</artifactId>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>io.envoyproxy.controlplane</groupId>
             <artifactId>cache</artifactId>
-            <version>1.0.52</version>
+            <version>1.0.53-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>java-control-plane</artifactId>
         <groupId>io.envoyproxy.controlplane</groupId>
-        <version>1.0.52</version>
+        <version>1.0.53-SNAPSHOT</version>
     </parent>
 
     <artifactId>test</artifactId>
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>io.envoyproxy.controlplane</groupId>
             <artifactId>cache</artifactId>
-            <version>1.0.52</version>
+            <version>1.0.53-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>io.envoyproxy.controlplane</groupId>
             <artifactId>server</artifactId>
-            <version>1.0.52</version>
+            <version>1.0.53-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Restore main to 1.0.53-SNAPSHOT; it was stuck at the already-released 1.0.52, due to which builds were failing:

https://app.circleci.com/pipelines/github/envoyproxy/java-control-plane/867/workflows/b3511fd3-a861-40e6-a701-98f47a204c27/jobs/1428